### PR TITLE
[REFACTOR] Extracted formatted text into a separate component (#232)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,11 +8,14 @@ module.exports = {
     'linebreak-style': 'off',
     'prefer-const': 'off',
     'react/react-in-jsx-scope': 'off',
-    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx', '.ts', '.tsx'] }],
+    'react/jsx-filename-extension': [
+      1,
+      { extensions: ['.js', '.jsx', '.ts', '.tsx'] },
+    ],
     /**
      * We'd normally want to keep this, but due to how the <Link> component in Next works,
      * we need to turn it off
-    */
+     */
     'jsx-a11y/anchor-is-valid': 'off',
     'react/jsx-props-no-spreading': 'off',
     'react/no-unescaped-entities': 'off',
@@ -34,15 +37,11 @@ module.exports = {
     'jsx-a11y/click-events-have-key-events': 'off',
     'jsx-a11y/no-noninteractive-element-interactions': 'off',
   },
-  plugins: [
-    '@typescript-eslint',
-  ],
+  plugins: ['@typescript-eslint'],
   settings: {
     'import/resolver': {
       alias: {
-        map: [
-          ['~', './client'],
-        ],
+        map: [['~', './client']],
         extensions: ['.js', '.jsx', '.ts', '.tsx', '.scss'],
       },
     },

--- a/client/components/FormattedText/FormattedText.module.scss
+++ b/client/components/FormattedText/FormattedText.module.scss
@@ -1,0 +1,12 @@
+@import '../../styles/variables';
+
+.formatted {
+  color: color(grey);
+  padding: 0.15em 0.3em;
+  display: inline-block;
+  background: color(darker-white);
+  border: 1px solid color(grey);
+  border-radius: 5px;
+  line-height: 1em;
+  font-family: 'Courier New', Courier, monospace;
+}

--- a/client/components/FormattedText/FormattedText.stories.tsx
+++ b/client/components/FormattedText/FormattedText.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import FormattedText from './FormattedText';
+
+export default {
+  title: 'FormattedText',
+};
+
+export const Default = () => (
+  <>
+    <FormattedText as="span">span</FormattedText>
+    <FormattedText as="strong">strong</FormattedText>
+  </>
+);

--- a/client/components/FormattedText/FormattedText.tsx
+++ b/client/components/FormattedText/FormattedText.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styles from './FormattedText.module.scss';
+
+type FormattedTextProps = {
+  as?: React.ComponentType | keyof JSX.IntrinsicElements;
+  children?: React.ReactNode;
+} & React.AllHTMLAttributes<HTMLOrSVGElement>;
+
+const FormattedText: React.FC<FormattedTextProps> = ({
+  as: Wrapper = 'div',
+  children,
+  ...props
+}) => {
+  return (
+    <Wrapper {...props} className={styles.formatted}>
+      {children}
+    </Wrapper>
+  );
+};
+
+export default FormattedText;

--- a/client/components/FormattedText/FormattedText.tsx
+++ b/client/components/FormattedText/FormattedText.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import styles from './FormattedText.module.scss';
 
 type FormattedTextProps = {
-  as?: React.ComponentType | keyof JSX.IntrinsicElements;
+  as?: keyof JSX.IntrinsicElements;
   children?: React.ReactNode;
-} & React.AllHTMLAttributes<HTMLOrSVGElement>;
+} & React.HTMLAttributes<HTMLOrSVGElement>;
 
-const FormattedText: React.FC<FormattedTextProps> = ({
+const FormattedText = ({
   as: Wrapper = 'div',
   children,
   ...props
-}) => {
+}: FormattedTextProps) => {
   return (
     <Wrapper {...props} className={styles.formatted}>
       {children}

--- a/client/components/FormattedText/index.ts
+++ b/client/components/FormattedText/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FormattedText';

--- a/client/components/GitCli/GitCli.tsx
+++ b/client/components/GitCli/GitCli.tsx
@@ -5,31 +5,31 @@ import Button from '~/components/Button';
 import styles from './GitCli.module.scss';
 
 interface Props {
-  commands: Commands[],
+  commands: Commands[];
 }
 
 interface State {
-  currentIndex: number,
-  messages: Message[],
-  btnMessage: string,
+  currentIndex: number;
+  messages: Message[];
+  btnMessage: string;
 }
 
 interface Commands {
-  command: RegExp | string,
-  message: string,
+  command: RegExp | string;
+  message: string;
 }
 
 interface Message {
-  text: string,
-  type: MessageType,
-  time: number,
-  id: string,
+  text: string;
+  type: MessageType;
+  time: number;
+  id: string;
 }
 
 enum MessageType {
   COMMAND = 'command',
   ERROR = 'error',
-  SUCCESS = 'success'
+  SUCCESS = 'success',
 }
 
 class MatchCommandMessageClassComponent extends React.Component<Props, State> {
@@ -56,7 +56,8 @@ class MatchCommandMessageClassComponent extends React.Component<Props, State> {
     if (commands[currentIndex].command instanceof RegExp) {
       isMatch = (commands[currentIndex].command as RegExp).test(gitCommand);
     } else {
-      isMatch = commands[currentIndex].command === gitCommand.trim().toLowerCase();
+      isMatch =
+        commands[currentIndex].command === gitCommand.trim().toLowerCase();
     }
 
     const commandMessage: Message = {
@@ -108,16 +109,11 @@ class MatchCommandMessageClassComponent extends React.Component<Props, State> {
             {messages.map((message) => (
               <p key={message.id} className={styles[message.type]}>
                 <span>{message.text}</span>
-                <span>
-                  {new Date(message.time).toLocaleString()}
-                </span>
+                <span>{new Date(message.time).toLocaleString()}</span>
               </p>
             ))}
           </div>
-          <form
-            className={styles.form}
-            onSubmit={this.handleSubmit}
-          >
+          <form className={styles.form} onSubmit={this.handleSubmit}>
             <input
               type="text"
               name="gitCommand"

--- a/client/components/GitCli/GitCli.tsx
+++ b/client/components/GitCli/GitCli.tsx
@@ -56,8 +56,7 @@ class MatchCommandMessageClassComponent extends React.Component<Props, State> {
     if (commands[currentIndex].command instanceof RegExp) {
       isMatch = (commands[currentIndex].command as RegExp).test(gitCommand);
     } else {
-      isMatch =
-        commands[currentIndex].command === gitCommand.trim().toLowerCase();
+      isMatch = commands[currentIndex].command === gitCommand.trim().toLowerCase();
     }
 
     const commandMessage: Message = {

--- a/client/curriculum/css/BoxModel.tsx
+++ b/client/curriculum/css/BoxModel.tsx
@@ -46,6 +46,7 @@ export default function BoxModelLesson() {
         <LessonCover>
           {/* eslint-disable-next-line react/no-danger */}
           <div
+            // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: coverSvg,
             }}
@@ -69,23 +70,29 @@ export default function BoxModelLesson() {
             Componentele Box Model
           </LessonHeading>
           <p>
-            <strong>Box model</strong> este compus din 4 proprietăți:
+            <strong>Box model</strong>
+            {' '}
+            este compus din 4 proprietăți:
           </p>
           <ul className="with--bullets">
             <li>
-              <strong>Content</strong>: Conținutul "cutiei", adică locul unde se
+              <strong>Content</strong>
+              : Conținutul "cutiei", adică locul unde se
               afișează textul / imaginea / etc.
             </li>
             <li>
-              <strong>Padding</strong>: Un spațiu transparent care înconjoară
+              <strong>Padding</strong>
+              : Un spațiu transparent care înconjoară
               conținutul
             </li>
             <li>
-              <strong>Border</strong>: O "bordură" care înconjoară conținutul și
+              <strong>Border</strong>
+              : O "bordură" care înconjoară conținutul și
               padding-ul
             </li>
             <li>
-              <strong>Margin</strong>: O suprafață transparentă din afara
+              <strong>Margin</strong>
+              : O suprafață transparentă din afara
               border-ului care ajută la spațierea dintre elemente
             </li>
           </ul>
@@ -99,10 +106,19 @@ export default function BoxModelLesson() {
           <p>
             În mod normal, dacă nu intervenim, majoritatea elementelor ar fi
             lipite unul de celălalt. Browserele aplică totuși câteva margini pe
-            anumite elemente, în special pe tag-urile de tip heading ({' '}
-            <FormattedText as="strong">{'<h1>'}</FormattedText> -{' '}
-            <FormattedText as="strong">{'<h6>'}</FormattedText> ) și pe
-            paragrafe ( <FormattedText as="strong">{'<p>'}</FormattedText> ),
+            anumite elemente, în special pe tag-urile de tip heading (
+            {' '}
+            <FormattedText as="strong">{'<h1>'}</FormattedText>
+            {' '}
+            -
+            {' '}
+            <FormattedText as="strong">{'<h6>'}</FormattedText>
+            {' '}
+            ) și pe
+            paragrafe (
+            <FormattedText as="strong">{'<p>'}</FormattedText>
+            {' '}
+            ),
             dar nu vom intra acum în detaliu.
           </p>
 
@@ -120,11 +136,15 @@ export default function BoxModelLesson() {
             alt="Doua elemente fara spatieri"
           />
           <p>
-            Așa cum se poate observa, ambele tag-uri{' '}
-            <FormattedText as="strong">{'<div>'}</FormattedText> sunt lipite. Nu
+            Așa cum se poate observa, ambele tag-uri
+            {' '}
+            <FormattedText as="strong">{'<div>'}</FormattedText>
+            {' '}
+            sunt lipite. Nu
             avem o spațiere definită, și nici vreo bordură pentru a le separa.
             Haideți să vedem cum putem folosi componentele box model-ului pentru
-            a schimba modul în care cele două{' '}
+            a schimba modul în care cele două
+            {' '}
             <FormattedText as="strong">{'<div>'}</FormattedText>
             -uri sunt afișate.
           </p>
@@ -156,8 +176,10 @@ div {
           <p>
             Setarea unui border pentru cele două div-uri ajută puțin la
             separare, însă elementele tot lipite sunt. Este departe de acel
-            design WOW pe care îl dorim. Pentru a le distanța, putem folosi{' '}
-            <strong>margin</strong>.
+            design WOW pe care îl dorim. Pentru a le distanța, putem folosi
+            {' '}
+            <strong>margin</strong>
+            .
           </p>
         </section>
         <section>
@@ -186,22 +208,28 @@ div {
           </p>
 
           <LessonTip>
-            Chiar dacă am setat 12px ca margin pentru ambele{' '}
+            Chiar dacă am setat 12px ca margin pentru ambele
+            {' '}
             <FormattedText as="strong">{'<div>'}</FormattedText>
             -uri, distanța dintre cele două elemente nu va fi 24px (12px * 2),
             ci va rămâne 12px. Acest lucru se întâmplă din cauza conceptului
-            numit <strong>margin collapsing</strong>. Este un fenomen care ar
+            numit
+            {' '}
+            <strong>margin collapsing</strong>
+            . Este un fenomen care ar
             merita propria mini-lecție, însă ceea ce trebuie să știi pentru
             moment este că uneori două margini se pot combina într-una singură,
             care va avea valoarea maximă dintre cele două margini individuale.
-            Poți citi mai multe{' '}
+            Poți citi mai multe
+            {' '}
             <Link href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">
               <a target="_blank">aici</a>
             </Link>
             .
           </LessonTip>
           <p>
-            Dacă deschidem DevTools și inspectăm unul dintre{' '}
+            Dacă deschidem DevTools și inspectăm unul dintre
+            {' '}
             <FormattedText as="strong">{'<div>'}</FormattedText>
             -uri, vom vedea imaginea de mai jos. Concret, chenarul portocaliu
             reprezintă de fapt marginea pe care noi am setat-o în cod, adică
@@ -219,7 +247,9 @@ div {
             Padding
           </LessonHeading>
           <p>
-            <strong>Padding-ul</strong> este folosit pentru a adăuga spațiu
+            <strong>Padding-ul</strong>
+            {' '}
+            este folosit pentru a adăuga spațiu
             între content și border. În exemplul nostru, padding-ul s-ar afișa
             între cuvântul "Element" și bordura neagră de 1px pe care noi am
             setat-o prima dată.
@@ -254,7 +284,10 @@ div {
           <p>
             Ok, acum că am învățat despre border, margin și padding, este
             momentul să vedem cum se aplică toate pe elementul din exemplu.
-            Pentru asta, vom folosi din nou <strong>DevTools</strong>.
+            Pentru asta, vom folosi din nou
+            {' '}
+            <strong>DevTools</strong>
+            .
           </p>
           <LessonFigure
             withBorder
@@ -274,14 +307,26 @@ div {
           </p>
           <p>
             În imaginea a doua, veți vedea exact dimensiunile setate pentru
-            margin, border și padding. Chenarul albastru este corespondentul{' '}
-            <strong>content-ului</strong>, care în exemplu are o lățime de{' '}
-            <em>372px</em> și o înălțime de <em>19px</em>.
+            margin, border și padding. Chenarul albastru este corespondentul
+            {' '}
+            <strong>content-ului</strong>
+            , care în exemplu are o lățime de
+            {' '}
+            <em>372px</em>
+            {' '}
+            și o înălțime de
+            <em>19px</em>
+            .
           </p>
           <p>
-            Haideți să setăm și proprietățile{' '}
-            <FormattedText as="strong">width</FormattedText> și{' '}
-            <FormattedText as="strong">height</FormattedText>, pentru a le vedea
+            Haideți să setăm și proprietățile
+            {' '}
+            <FormattedText as="strong">width</FormattedText>
+            {' '}
+            și
+            {' '}
+            <FormattedText as="strong">height</FormattedText>
+            , pentru a le vedea
             modificate și în reprezentarea grafică.
           </p>
           <Highlight
@@ -312,9 +357,21 @@ div {
             alt="Box Model complet, vizualizat pe pagina"
           />
           <p>
-            Hmm, ceva nu e bine. Am setat lățimea de <em>100px</em> și înălțimea
-            de <em>50px</em>, însă div-ul nostru are în schimb o lățime de{' '}
-            <em>118px</em> și o înălțime de <em>68px</em>. Oare de ce?
+            Hmm, ceva nu e bine. Am setat lățimea de
+            {' '}
+            <em>100px</em>
+            {' '}
+            și înălțimea
+            de
+            {' '}
+            <em>50px</em>
+            , însă div-ul nostru are în schimb o lățime de
+            {' '}
+            <em>118px</em>
+            {' '}
+            și o înălțime de
+            <em>68px</em>
+            . Oare de ce?
           </p>
         </section>
         <section>
@@ -323,15 +380,20 @@ div {
           </LessonHeading>
           <p>
             Pentru a înțelege ce s-a întâmplat, trebuie să vorbim puțin despre
-            proprietatea <FormattedText as="strong">box-sizing</FormattedText>.
+            proprietatea
+            {' '}
+            <FormattedText as="strong">box-sizing</FormattedText>
+            .
           </p>
           <p>
             Această proprietate controlează modul în care este calculată
             dimensiunea totală a unui element (lățime și înălțime).
           </p>
           <p>
-            În CSS, dacă setam o lățime de 100px, ea se va aplica asupra{' '}
-            <strong>content-ului</strong>. În momentul în care adăugăm padding
+            În CSS, dacă setam o lățime de 100px, ea se va aplica asupra
+            {' '}
+            <strong>content-ului</strong>
+            . În momentul în care adăugăm padding
             sau border, aceste valori se vor adăuga la dimensiunea totală a
             elementului final care va fi randat pe pagină.
           </p>
@@ -358,11 +420,17 @@ div {
           </p>
           <blockquote>100px + 8px * 2 + 1px * 2 = 118px</blockquote>
           <LessonTip>
-            De ce 8px * 2? Trebuie să luăm în considerare{' '}
-            <FormattedText as="strong">padding-left</FormattedText> și{' '}
-            <FormattedText as="strong">padding-right</FormattedText>. Același
+            De ce 8px * 2? Trebuie să luăm în considerare
+            {' '}
+            <FormattedText as="strong">padding-left</FormattedText>
+            {' '}
+            și
+            {' '}
+            <FormattedText as="strong">padding-right</FormattedText>
+            . Același
             lucru este valabil și pentru
-            <FormattedText as="strong">border</FormattedText>.
+            <FormattedText as="strong">border</FormattedText>
+            .
           </LessonTip>
           <p>
             Se poate observa că nu este neapărat un mod ușor de a seta
@@ -371,16 +439,28 @@ div {
             ajungem la rezultatul dorit. Asta nu sună prea bine, nu?
           </p>
           <p>
-            Din fericire, CSS ne oferă o soluție: proprietatea{' '}
-            <FormattedText as="strong">box-sizing</FormattedText>. Implicit,
-            această proprietate are valoarea{' '}
-            <FormattedText as="strong">content-box</FormattedText>, adică{' '}
-            <em>width-ul</em> și <em>height-ul</em> se vor aplica asupra
+            Din fericire, CSS ne oferă o soluție: proprietatea
+            {' '}
+            <FormattedText as="strong">box-sizing</FormattedText>
+            . Implicit,
+            această proprietate are valoarea
+            {' '}
+            <FormattedText as="strong">content-box</FormattedText>
+            , adică
+            {' '}
+            <em>width-ul</em>
+            {' '}
+            și
+            <em>height-ul</em>
+            {' '}
+            se vor aplica asupra
             content-ului.
           </p>
           <p>
-            Cealaltă valoare este{' '}
-            <FormattedText as="strong">border-box</FormattedText>. Setarea
+            Cealaltă valoare este
+            {' '}
+            <FormattedText as="strong">border-box</FormattedText>
+            . Setarea
             acestei valori îi va spune browser-ului să țină cont pentru
             calcularea dimensiuni de orice border sau padding adăugat.
             Content-ul va fi micșorat pentru a se putea atinge width-ul sau
@@ -419,8 +499,10 @@ div {
           <p>
             Mai jos, am recreat box model-ul din DevTools, pentru că tu să poți
             interacționa cu el și pentru a vedea în timp real cum este afectată
-            dimensiunea elementului în funcție de valoarea proprietății{' '}
-            <FormattedText as="strong">box-sizing</FormattedText>.
+            dimensiunea elementului în funcție de valoarea proprietății
+            {' '}
+            <FormattedText as="strong">box-sizing</FormattedText>
+            .
           </p>
           <LessonTip>
             Valorile implicite setate în stânga servesc drept limite maxime,

--- a/client/curriculum/css/BoxModel.tsx
+++ b/client/curriculum/css/BoxModel.tsx
@@ -14,6 +14,7 @@ import Highlight from '~/components/Highlight/Highlight';
 import DevToolsClone from '~/components/DevToolsClone';
 import SideBySidePictures from '~/components/SideBySidePictures';
 import coverSvg from '~/public/images/lessons/box-model/cover.svg';
+import FormattedText from '~/components/FormattedText';
 
 const contributors = [CatalinPopusoi];
 const chapters = [
@@ -35,52 +36,57 @@ export default function BoxModelLesson() {
         description="Deși unele site-uri sunt cu adevărat WOW, fiecare element e de fapt un dreptunghi cu câteva proprietăți mai speciale numit Box Model. Aici învățăm despre el."
         url="https://FrontEnd.ro/css/box-model"
       />
-      <Lesson id="box-model" title="Box Model" chapters={chapters} withExercises={false}>
+      <Lesson
+        id="box-model"
+        title="Box Model"
+        chapters={chapters}
+        withExercises={false}
+      >
         <LessonContributors className="absolute" contributors={contributors} />
         <LessonCover>
           {/* eslint-disable-next-line react/no-danger */}
-          <div dangerouslySetInnerHTML={{
-            __html: coverSvg,
-          }}
+          <div
+            dangerouslySetInnerHTML={{
+              __html: coverSvg,
+            }}
           />
         </LessonCover>
         <p>
-          Până acum, am învățat ce înseamnă CSS, la ce îl putem folosi, și, foarte important,
-          cum să îl folosim. CSS este un limbaj cu care putem crea site-uri cu un design excelent.
-          La bază, fiecare element e doar un dreptunghi cu câteva proprietăți mai speciale.
+          Până acum, am învățat ce înseamnă CSS, la ce îl putem folosi, și,
+          foarte important, cum să îl folosim. CSS este un limbaj cu care putem
+          crea site-uri cu un design excelent. La bază, fiecare element e doar
+          un dreptunghi cu câteva proprietăți mai speciale.
         </p>
         <p>
-          În această lecție vom învăța despre box-model: din ce este compus și cum este folosit
-          “în spate” pentru a crea acele design-uri WOW. Înțelegerea modului în care
-          lucrează este cheia care te va ajuta să construiești orice interfață și să
-          rezolvi diverse probleme de layout ce pot apărea.
+          În această lecție vom învăța despre box-model: din ce este compus și
+          cum este folosit “în spate” pentru a crea acele design-uri WOW.
+          Înțelegerea modului în care lucrează este cheia care te va ajuta să
+          construiești orice interfață și să rezolvi diverse probleme de layout
+          ce pot apărea.
         </p>
         <section>
           <LessonHeading as="h2" id="componentele-box-model">
             Componentele Box Model
           </LessonHeading>
           <p>
-            <strong>Box model</strong>
-            {' '}
-            este compus din 4 proprietăți:
+            <strong>Box model</strong> este compus din 4 proprietăți:
           </p>
           <ul className="with--bullets">
             <li>
-              <strong>Content</strong>
-              : Conținutul "cutiei", adică locul unde se afișează textul / imaginea / etc.
+              <strong>Content</strong>: Conținutul "cutiei", adică locul unde se
+              afișează textul / imaginea / etc.
             </li>
             <li>
-              <strong>Padding</strong>
-              : Un spațiu transparent care înconjoară conținutul
+              <strong>Padding</strong>: Un spațiu transparent care înconjoară
+              conținutul
             </li>
             <li>
-              <strong>Border</strong>
-              : O "bordură" care înconjoară conținutul și padding-ul
+              <strong>Border</strong>: O "bordură" care înconjoară conținutul și
+              padding-ul
             </li>
             <li>
-              <strong>Margin</strong>
-              : O suprafață transparentă din afara border-ului
-              care ajută la spațierea dintre elemente
+              <strong>Margin</strong>: O suprafață transparentă din afara
+              border-ului care ajută la spațierea dintre elemente
             </li>
           </ul>
 
@@ -91,22 +97,12 @@ export default function BoxModelLesson() {
           />
 
           <p>
-            În mod normal, dacă nu intervenim, majoritatea elementelor ar fi lipite unul de
-            celălalt. Browserele aplică totuși câteva margini pe anumite
-            elemente, în special pe tag-urile de tip heading
-            (
-            {' '}
-            <strong className="formatted">{'<h1>'}</strong>
-            {' '}
-            -
-            {' '}
-            <strong className="formatted">{'<h6>'}</strong>
-            {' '}
-            ) și pe paragrafe (
-            {' '}
-            <strong className="formatted">{'<p>'}</strong>
-            {' '}
-            ),
+            În mod normal, dacă nu intervenim, majoritatea elementelor ar fi
+            lipite unul de celălalt. Browserele aplică totuși câteva margini pe
+            anumite elemente, în special pe tag-urile de tip heading ({' '}
+            <FormattedText as="strong">{'<h1>'}</FormattedText> -{' '}
+            <FormattedText as="strong">{'<h6>'}</FormattedText> ) și pe
+            paragrafe ( <FormattedText as="strong">{'<p>'}</FormattedText> ),
             dar nu vom intra acum în detaliu.
           </p>
 
@@ -124,15 +120,12 @@ export default function BoxModelLesson() {
             alt="Doua elemente fara spatieri"
           />
           <p>
-            Așa cum se poate observa, ambele tag-uri
-            {' '}
-            <strong className="formatted">{'<div>'}</strong>
-            {' '}
-            sunt lipite. Nu avem o spațiere definită, și nici vreo bordură pentru a le separa.
-            Haideți să vedem cum putem folosi componentele box model-ului pentru a schimba modul în
-            care cele două
-            {' '}
-            <strong className="formatted">{'<div>'}</strong>
+            Așa cum se poate observa, ambele tag-uri{' '}
+            <FormattedText as="strong">{'<div>'}</FormattedText> sunt lipite. Nu
+            avem o spațiere definită, și nici vreo bordură pentru a le separa.
+            Haideți să vedem cum putem folosi componentele box model-ului pentru
+            a schimba modul în care cele două{' '}
+            <FormattedText as="strong">{'<div>'}</FormattedText>
             -uri sunt afișate.
           </p>
         </section>
@@ -141,8 +134,9 @@ export default function BoxModelLesson() {
             Border
           </LessonHeading>
           <p>
-            Vom începe cu border. Border nu va adăuga spațiere propriu-zisă între elemente, însă va
-            ajuta la setarea unor limite vizuale pentru acestea.
+            Vom începe cu border. Border nu va adăuga spațiere propriu-zisă
+            între elemente, însă va ajuta la setarea unor limite vizuale pentru
+            acestea.
           </p>
           <Highlight
             className="my-5"
@@ -160,12 +154,10 @@ div {
           />
 
           <p>
-            Setarea unui border pentru cele două div-uri ajută puțin la separare, însă
-            elementele tot lipite sunt. Este departe de acel design WOW pe care îl
-            dorim. Pentru a le distanța, putem folosi
-            {' '}
-            <strong>margin</strong>
-            .
+            Setarea unui border pentru cele două div-uri ajută puțin la
+            separare, însă elementele tot lipite sunt. Este departe de acel
+            design WOW pe care îl dorim. Pentru a le distanța, putem folosi{' '}
+            <strong>margin</strong>.
           </p>
         </section>
         <section>
@@ -189,41 +181,31 @@ div {
           />
 
           <p>
-            Deja putem vedea o îmbunătățire. Cele două div-uri nu mai sunt lipite, ci au
-            puțin spațiu între ele, 12px mai exact.
+            Deja putem vedea o îmbunătățire. Cele două div-uri nu mai sunt
+            lipite, ci au puțin spațiu între ele, 12px mai exact.
           </p>
 
           <LessonTip>
-            Chiar dacă am setat 12px ca margin pentru ambele
-            {' '}
-            <strong className="formatted">{'<div>'}</strong>
-            -uri,
-            distanța dintre cele două elemente nu va fi 24px (12px * 2), ci va rămâne 12px.
-            Acest lucru se întâmplă din cauza conceptului numit
-            {' '}
-            <strong>margin collapsing</strong>
-            .
-            Este un fenomen care ar merita propria mini-lecție, însă ceea ce trebuie să știi pentru
+            Chiar dacă am setat 12px ca margin pentru ambele{' '}
+            <FormattedText as="strong">{'<div>'}</FormattedText>
+            -uri, distanța dintre cele două elemente nu va fi 24px (12px * 2),
+            ci va rămâne 12px. Acest lucru se întâmplă din cauza conceptului
+            numit <strong>margin collapsing</strong>. Este un fenomen care ar
+            merita propria mini-lecție, însă ceea ce trebuie să știi pentru
             moment este că uneori două margini se pot combina într-una singură,
             care va avea valoarea maximă dintre cele două margini individuale.
-            Poți citi mai multe
-            {' '}
-            {' '}
+            Poți citi mai multe{' '}
             <Link href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">
-              <a target="_blank">
-                aici
-              </a>
+              <a target="_blank">aici</a>
             </Link>
             .
           </LessonTip>
           <p>
-            Dacă deschidem DevTools și inspectăm unul dintre
-            {' '}
-            <strong className="formatted">{'<div>'}</strong>
-            -uri,
-            vom vedea imaginea de mai jos. Concret, chenarul portocaliu reprezintă
-            de fapt marginea pe care noi am setat-o în cod, adică 12px în toate
-            direcțiile (top, right, bottom, left).
+            Dacă deschidem DevTools și inspectăm unul dintre{' '}
+            <FormattedText as="strong">{'<div>'}</FormattedText>
+            -uri, vom vedea imaginea de mai jos. Concret, chenarul portocaliu
+            reprezintă de fapt marginea pe care noi am setat-o în cod, adică
+            12px în toate direcțiile (top, right, bottom, left).
           </p>
 
           <LessonFigure
@@ -237,11 +219,10 @@ div {
             Padding
           </LessonHeading>
           <p>
-            <strong>Padding-ul</strong>
-            {' '}
-            este folosit pentru a adăuga spațiu între content și border.
-            În exemplul nostru, padding-ul s-ar afișa între cuvântul "Element"
-            și bordura neagră de 1px pe care noi am setat-o prima dată.
+            <strong>Padding-ul</strong> este folosit pentru a adăuga spațiu
+            între content și border. În exemplul nostru, padding-ul s-ar afișa
+            între cuvântul "Element" și bordura neagră de 1px pe care noi am
+            setat-o prima dată.
           </p>
 
           <Highlight
@@ -261,8 +242,9 @@ div {
             alt="Element cu padding aplicat"
           />
           <p>
-            Chenarul verde este echivalentul padding-ului de 8px setat. După cum se poate observa,
-            cuvântul "Element" este acum mai distanțat față de bordură.
+            Chenarul verde este echivalentul padding-ului de 8px setat. După cum
+            se poate observa, cuvântul "Element" este acum mai distanțat față de
+            bordură.
           </p>
         </section>
         <section>
@@ -270,11 +252,9 @@ div {
             DevTools Box Model
           </LessonHeading>
           <p>
-            Ok, acum că am învățat despre border, margin și padding, este momentul să vedem cum se
-            aplică toate pe elementul din exemplu. Pentru asta, vom folosi din nou
-            {' '}
-            <strong>DevTools</strong>
-            .
+            Ok, acum că am învățat despre border, margin și padding, este
+            momentul să vedem cum se aplică toate pe elementul din exemplu.
+            Pentru asta, vom folosi din nou <strong>DevTools</strong>.
           </p>
           <LessonFigure
             withBorder
@@ -288,37 +268,21 @@ div {
           />
 
           <p>
-            Prima imagine ar trebui să vă fie familiară.
-            Acolo veți regăsi elementul îmbunătățit vizual
-            cu reprezentarea grafică a tuturor proprietăților
-            ce compun box model-ul.
+            Prima imagine ar trebui să vă fie familiară. Acolo veți regăsi
+            elementul îmbunătățit vizual cu reprezentarea grafică a tuturor
+            proprietăților ce compun box model-ul.
           </p>
           <p>
-            În imaginea a doua, veți vedea exact dimensiunile setate
-            pentru margin, border și padding.
-            Chenarul albastru este corespondentul
-            {' '}
-            <strong>content-ului</strong>
-            , care în exemplu are o
-            lățime de
-            {' '}
-            <em>372px</em>
-            {' '}
-            și o înălțime de
-            {' '}
-            <em>19px</em>
-            .
+            În imaginea a doua, veți vedea exact dimensiunile setate pentru
+            margin, border și padding. Chenarul albastru este corespondentul{' '}
+            <strong>content-ului</strong>, care în exemplu are o lățime de{' '}
+            <em>372px</em> și o înălțime de <em>19px</em>.
           </p>
           <p>
-            Haideți să setăm și proprietățile
-            {' '}
-            <strong className="formatted">width</strong>
-            {' '}
-            și
-            {' '}
-            <strong className="formatted">height</strong>
-            , pentru a le vedea modificate și în
-            reprezentarea grafică.
+            Haideți să setăm și proprietățile{' '}
+            <FormattedText as="strong">width</FormattedText> și{' '}
+            <FormattedText as="strong">height</FormattedText>, pentru a le vedea
+            modificate și în reprezentarea grafică.
           </p>
           <Highlight
             className="my-5"
@@ -339,8 +303,8 @@ div {
             alt="Box Model complet, vizualizat in DevTools"
           />
           <p>
-            Ok, acum am setat toate valorile unui box model.
-            Putem observa asta și pe elementul din pagină.
+            Ok, acum am setat toate valorile unui box model. Putem observa asta
+            și pe elementul din pagină.
           </p>
           <LessonFigure
             withBorder
@@ -348,23 +312,9 @@ div {
             alt="Box Model complet, vizualizat pe pagina"
           />
           <p>
-            Hmm, ceva nu e bine. Am setat lățimea de
-            {' '}
-            <em>100px</em>
-            {' '}
-            și înălțimea de
-            {' '}
-            <em>50px</em>
-            , însă
-            div-ul nostru are în schimb o lățime de
-            {' '}
-            <em>118px</em>
-            {' '}
-            și o înălțime de
-            {' '}
-            <em>68px</em>
-            .
-            Oare de ce?
+            Hmm, ceva nu e bine. Am setat lățimea de <em>100px</em> și înălțimea
+            de <em>50px</em>, însă div-ul nostru are în schimb o lățime de{' '}
+            <em>118px</em> și o înălțime de <em>68px</em>. Oare de ce?
           </p>
         </section>
         <section>
@@ -372,29 +322,22 @@ div {
             Box-sizing
           </LessonHeading>
           <p>
-            Pentru a înțelege ce s-a întâmplat, trebuie să vorbim puțin despre proprietatea
-            {' '}
-            {' '}
-            <strong className="formatted">box-sizing</strong>
-            .
+            Pentru a înțelege ce s-a întâmplat, trebuie să vorbim puțin despre
+            proprietatea <FormattedText as="strong">box-sizing</FormattedText>.
           </p>
           <p>
-            Această proprietate controlează modul în care este calculată dimensiunea totală a unui
-            element (lățime și înălțime).
+            Această proprietate controlează modul în care este calculată
+            dimensiunea totală a unui element (lățime și înălțime).
           </p>
           <p>
-            În CSS, dacă setam o lățime de 100px, ea se va aplica asupra
-            {' '}
-            <strong>content-ului</strong>
-            .
-            În momentul în care adăugăm padding sau border,
-            aceste valori se vor adăuga la dimensiunea
-            totală a elementului final care va fi randat pe pagină.
+            În CSS, dacă setam o lățime de 100px, ea se va aplica asupra{' '}
+            <strong>content-ului</strong>. În momentul în care adăugăm padding
+            sau border, aceste valori se vor adăuga la dimensiunea totală a
+            elementului final care va fi randat pe pagină.
           </p>
           <p>
-            Hai să ne întoarcem la exemplul nostru.
-            Ne vom concentra atenția asupra lățimii, întrucât
-            înălțimea are același mod de calcul.
+            Hai să ne întoarcem la exemplul nostru. Ne vom concentra atenția
+            asupra lățimii, întrucât înălțimea are același mod de calcul.
           </p>
           <Highlight
             className="my-5"
@@ -410,64 +353,42 @@ div {
             `}
           />
           <p>
-            Avem setat un width: 100px, un padding:
-            8px și un border: 1px. Modul în care este calculată
-            lățimea este următorul:
+            Avem setat un width: 100px, un padding: 8px și un border: 1px. Modul
+            în care este calculată lățimea este următorul:
           </p>
-          <blockquote>
-            100px + 8px * 2 + 1px * 2 = 118px
-          </blockquote>
+          <blockquote>100px + 8px * 2 + 1px * 2 = 118px</blockquote>
           <LessonTip>
-            De ce 8px * 2? Trebuie să luăm în considerare
-            {' '}
-            <strong className="formatted">padding-left</strong>
-            {' '}
-            și
-            {' '}
-            <strong className="formatted">padding-right</strong>
-            . Același lucru este valabil și pentru
-            <strong className="formatted">border</strong>
-            .
+            De ce 8px * 2? Trebuie să luăm în considerare{' '}
+            <FormattedText as="strong">padding-left</FormattedText> și{' '}
+            <FormattedText as="strong">padding-right</FormattedText>. Același
+            lucru este valabil și pentru
+            <FormattedText as="strong">border</FormattedText>.
           </LessonTip>
           <p>
-            Se poate observa că nu este neapărat un mod ușor
-            de a seta dimensiuni. Dacă avem nevoie de o
-            anumită lățime, trebuie să ne gândim la ce border
-            și ce padding vom seta, pentru a reuși să ajungem
-            la rezultatul dorit. Asta nu sună prea bine, nu?
+            Se poate observa că nu este neapărat un mod ușor de a seta
+            dimensiuni. Dacă avem nevoie de o anumită lățime, trebuie să ne
+            gândim la ce border și ce padding vom seta, pentru a reuși să
+            ajungem la rezultatul dorit. Asta nu sună prea bine, nu?
           </p>
           <p>
-            Din fericire, CSS ne oferă o soluție: proprietatea
-            {' '}
-            <strong className="formatted">box-sizing</strong>
-            .
-            Implicit, această proprietate are valoarea
-            {' '}
-            <strong className="formatted">content-box</strong>
-            ,
-            adică
-            {' '}
-            <em>width-ul</em>
-            {' '}
-            și
-            {' '}
-            <em>height-ul</em>
-            {' '}
-            se vor aplica asupra content-ului.
+            Din fericire, CSS ne oferă o soluție: proprietatea{' '}
+            <FormattedText as="strong">box-sizing</FormattedText>. Implicit,
+            această proprietate are valoarea{' '}
+            <FormattedText as="strong">content-box</FormattedText>, adică{' '}
+            <em>width-ul</em> și <em>height-ul</em> se vor aplica asupra
+            content-ului.
           </p>
           <p>
-            Cealaltă valoare este
-            {' '}
-            <strong className="formatted">border-box</strong>
-            . Setarea acestei
-            valori îi va spune browser-ului să țină cont
-            pentru calcularea dimensiuni de orice border
-            sau padding adăugat. Content-ul va fi micșorat
-            pentru a se putea atinge width-ul sau
+            Cealaltă valoare este{' '}
+            <FormattedText as="strong">border-box</FormattedText>. Setarea
+            acestei valori îi va spune browser-ului să țină cont pentru
+            calcularea dimensiuni de orice border sau padding adăugat.
+            Content-ul va fi micșorat pentru a se putea atinge width-ul sau
             height-ul setat.
           </p>
           <p>
-            În imaginile de mai jos putem vedea exact aceste diferențe de la nivelul content-ului.
+            În imaginile de mai jos putem vedea exact aceste diferențe de la
+            nivelul content-ului.
           </p>
           <SideBySidePictures
             direction="row"
@@ -481,9 +402,8 @@ div {
             }}
           />
           <p>
-            Diferența este vizibilă și în pagină, unde
-            elementele sunt randate în forma finală, după ce toate
-            calculele au fost făcute.
+            Diferența este vizibilă și în pagină, unde elementele sunt randate
+            în forma finală, după ce toate calculele au fost făcute.
           </p>
           <LessonFigure
             withBorder
@@ -495,44 +415,45 @@ div {
           <LessonHeading as="h2" id="box-model-interactiv">
             Box Model Interactiv
           </LessonHeading>
+          <p>Ok, gata cu vorba. Hai să trecem și la ceva practic.</p>
           <p>
-            Ok, gata cu vorba. Hai să trecem și la ceva practic.
-          </p>
-          <p>
-            Mai jos, am recreat box model-ul din DevTools, pentru că tu să poți interacționa cu el
-            și pentru a vedea în timp real cum este afectată dimensiunea elementului în funcție de
-            valoarea proprietății
-            {' '}
-            <strong className="formatted">box-sizing</strong>
-            .
+            Mai jos, am recreat box model-ul din DevTools, pentru că tu să poți
+            interacționa cu el și pentru a vedea în timp real cum este afectată
+            dimensiunea elementului în funcție de valoarea proprietății{' '}
+            <FormattedText as="strong">box-sizing</FormattedText>.
           </p>
           <LessonTip>
             Valorile implicite setate în stânga servesc drept limite maxime,
-            pentru a nu strica layout-ul general al paginii.
-            Pentru a interacționa cu valorile, este suficient să setați
-            orice valoare pozitivă mai mică decât acest maxim.
-            La schimbarea checkbox-ului activ, ar trebui să
-            vedeți valoarea finală modificată în funcție de alegerea voastră.
+            pentru a nu strica layout-ul general al paginii. Pentru a
+            interacționa cu valorile, este suficient să setați orice valoare
+            pozitivă mai mică decât acest maxim. La schimbarea checkbox-ului
+            activ, ar trebui să vedeți valoarea finală modificată în funcție de
+            alegerea voastră.
           </LessonTip>
           <DevToolsClone />
         </section>
         <div className="dots" />
         <section>
           <p>
-            Am acoperit destul de multă teorie în această lecție. Sper că acum este puțin mai clar
-            cum este folosit box model in CSS. Dacă totuși consideri că ai nevoie de ceva mai multe
-            informații, poți folosi una dintre resursele de mai jos:
+            Am acoperit destul de multă teorie în această lecție. Sper că acum
+            este puțin mai clar cum este folosit box model in CSS. Dacă totuși
+            consideri că ai nevoie de ceva mai multe informații, poți folosi una
+            dintre resursele de mai jos:
           </p>
 
           <LessonResources
             className="my-5"
-            links={[{
-              text: 'Documentația completă a box model-ului pe MDN',
-              url: 'https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/The_box_model',
-            }, {
-              text: 'Documentația completă a proprietății box-sizing pe MDN',
-              url: 'https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing',
-            },
+            links={[
+              {
+                text: 'Documentația completă a box model-ului pe MDN',
+                url:
+                  'https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/The_box_model',
+              },
+              {
+                text: 'Documentația completă a proprietății box-sizing pe MDN',
+                url:
+                  'https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing',
+              },
             ]}
           />
         </section>

--- a/client/curriculum/css/StylingMethods.tsx
+++ b/client/curriculum/css/StylingMethods.tsx
@@ -12,6 +12,7 @@ import Highlight from '~/components/Highlight/Highlight';
 import coverSvg from '~/public/images/lessons/styling-methods__cover.svg';
 import BasicEditorLazy from '~/components/Editor/BasicEditor/BasicEditor.lazy';
 import { ExerciseFile, ExerciseFolder } from '~/services/utils/FolderStructure';
+import FormattedText from '~/components/FormattedText';
 
 const contributors = [DanielHutanu];
 const chapters = [
@@ -34,7 +35,11 @@ export default function CssStylingLesson() {
         description="Învață modurile prin care putem aplica stiluri paginilor Web."
         url="https://FrontEnd.ro/css/moduri-stilizare"
       />
-      <Lesson id="moduri-stilizare" title="Cele 3 moduri de stilizare" chapters={chapters}>
+      <Lesson
+        id="moduri-stilizare"
+        title="Cele 3 moduri de stilizare"
+        chapters={chapters}
+      >
         <LessonContributors className="absolute" contributors={contributors} />
         <LessonCover>
           <div
@@ -46,43 +51,23 @@ export default function CssStylingLesson() {
         </LessonCover>
         <p>
           În acest articol vom vorbi despre cele trei modalități prin care putem
-          aplica stilul unei pagini web:
-          {' '}
-          <strong>
-            CSS inline
-          </strong>
-          ,
-          {' '}
-          <strong>
-            CSS intern
-          </strong>
-          {' '}
-          sau
-          {' '}
-          <strong>
-            CSS extern
-          </strong>
-          .
-          Fiecare metoda vine cu avantaje și dezavantaje, despre care vom vorbi
-          în cele ce urmează.
+          aplica stilul unei pagini web: <strong>CSS inline</strong>,{' '}
+          <strong>CSS intern</strong> sau <strong>CSS extern</strong>. Fiecare
+          metoda vine cu avantaje și dezavantaje, despre care vom vorbi în cele
+          ce urmează.
         </p>
         <section>
           <LessonHeading as="h3" id="css-inline">
             CSS inline
           </LessonHeading>
           <p>
-            Prin
-            {' '}
-            <strong className="formatted">CSS inline</strong>
-            {' '}
-            putem aplica stilul unui singur element HTML.
+            Prin <FormattedText as="strong">CSS inline</FormattedText> putem
+            aplica stilul unui singur element HTML.
           </p>
           <p>
-            Scrierea codului CSS se va face prin adaugarea atributului
-            {' '}
-            <strong className="formatted">style</strong>
-            {' '}
-            pe elementul căruia vrem să-i modificăm stilul:
+            Scrierea codului CSS se va face prin adaugarea atributului{' '}
+            <FormattedText as="strong">style</FormattedText> pe elementul căruia
+            vrem să-i modificăm stilul:
           </p>
           <Highlight
             className="my-5"
@@ -111,10 +96,7 @@ export default function CssStylingLesson() {
             demo="/demo/css/css-inline"
           />
           <p>
-            Metoda inline vine la pachet cu
-            {' '}
-            <strong>dezavantaje uriașe</strong>
-            {' '}
+            Metoda inline vine la pachet cu <strong>dezavantaje uriașe</strong>{' '}
             și din această cauză majoritatea programatorilor o evită. Hai să
             vedem de ce nu e indicată:
           </p>
@@ -123,21 +105,20 @@ export default function CssStylingLesson() {
               dacă avem de stilizat mai multe elemente similare, (să zicem mai
               multe paragrafe care vrem să arate la fel) , prin metoda inline va
               trebui să facem copy-paste la cod pentru fiecare paragraf în
-              parte. Mai mult, când o să ne răzgândim
-              asupra stilurilor, va trebuie să ținem minte și să modificăm peste tot.
+              parte. Mai mult, când o să ne răzgândim asupra stilurilor, va
+              trebuie să ținem minte și să modificăm peste tot.
             </li>
             <li>
               vedem că e greu să distingem codul CSS de cel HTML (se produce un
-              așa numit efect de
-              {' '}
-              <strong>spaghetti code</strong>
-              ). Așadar, ne va fi dificil să înțelegem și să facem modificări pe un astfel de
-              cod.
+              așa numit efect de <strong>spaghetti code</strong>
+              ). Așadar, ne va fi dificil să înțelegem și să facem modificări pe
+              un astfel de cod.
             </li>
           </ul>
           <LessonTip>
-            Aceasta este prima și cea mai ușor de înțeles metodă prin care
-            putem stiliza o pagină web, dar după cum am menționat mai sus, nu este recomandată.
+            Aceasta este prima și cea mai ușor de înțeles metodă prin care putem
+            stiliza o pagină web, dar după cum am menționat mai sus, nu este
+            recomandată.
           </LessonTip>
         </section>
         <section>
@@ -146,28 +127,17 @@ export default function CssStylingLesson() {
           </LessonHeading>
           <p>
             Dacă prin metoda inline trebuie să stilizăm câte un element pe rând,
-            printr-un
-            {' '}
-            <strong>CSS intern</strong>
-            {' '}
-            putem
-            controla stilul pentru o întreagă pagină, scăpând astfel de codul
-            duplicat. Totodată, vom avea o mai bună înțelegere a codului și vom
-            câștiga timp.
+            printr-un <strong>CSS intern</strong> putem controla stilul pentru o
+            întreagă pagină, scăpând astfel de codul duplicat. Totodată, vom
+            avea o mai bună înțelegere a codului și vom câștiga timp.
           </p>
           <p>
             Metoda de integrare a codului CSS în pagina web se va face prin
-            inserarea elementului
-            {' '}
-            <strong className="formatted">{'<style>'}</strong>
-            {' '}
-            în secțiunea
-            {' '}
-            <strong className="formatted">{'<head>'}</strong>
-            {' '}
-            a documentului
-            HTML. Față de metoda anterioară, la aceasta trebuie să precizăm pentru ce elemente
-            vom aplica regulile de stilizare.
+            inserarea elementului{' '}
+            <FormattedText as="strong">{'<style>'}</FormattedText> în secțiunea{' '}
+            <FormattedText as="strong">{'<head>'}</FormattedText> a documentului
+            HTML. Față de metoda anterioară, la aceasta trebuie să precizăm
+            pentru ce elemente vom aplica regulile de stilizare.
           </p>
           <Highlight
             className="my-5"
@@ -182,23 +152,18 @@ export default function CssStylingLesson() {
 </style>`}
           />
           <p>
-            În exemplul de mai sus aplicăm regulile
-            pe toate elementele de tip
-            {' '}
-            <strong className="formatted">a</strong>
-            {' '}
-            ,
-            {' '}
-            selectorul folosit fiind tagul elementului HTML.
+            În exemplul de mai sus aplicăm regulile pe toate elementele de tip{' '}
+            <FormattedText as="strong">a</FormattedText> , selectorul folosit
+            fiind tagul elementului HTML.
           </p>
           <LessonTip>
-            Există și alți selectori: după clasă sau id. Vom vorbi de ei în lecțiile următoare,
-            însă pentru moment e important să reții această metodă de stilizare și
-            rolul selectorilor.
+            Există și alți selectori: după clasă sau id. Vom vorbi de ei în
+            lecțiile următoare, însă pentru moment e important să reții această
+            metodă de stilizare și rolul selectorilor.
           </LessonTip>
           <p>
-            Uite mai jos un exemplu mai complet, în
-            care aplicăm stiluri pe elementul main, heading-uri, paragrafe:
+            Uite mai jos un exemplu mai complet, în care aplicăm stiluri pe
+            elementul main, heading-uri, paragrafe:
           </p>
           <Highlight
             className="my-5"
@@ -254,29 +219,19 @@ export default function CssStylingLesson() {
             demo="/demo/css/css-intern"
           />
           <p>
-            Observăm că în acest caz codul HTML este puțin mai separat față de CSS ceea ce
-            e o îmbunătățire față de metoda anterioară.
+            Observăm că în acest caz codul HTML este puțin mai separat față de
+            CSS ceea ce e o îmbunătățire față de metoda anterioară.
           </p>
           <p>
-            În practică însă,
-            {' '}
-            <strong>
-              nu recomandăm nici folosirea metodei interne
-            </strong>
-            {' '}
-            pentru că site-urile sunt
-            construite din mai multe pagini deci vom ajunge iar să facem copy-paste în
-            fiecare pagină.
-            Plus, deși codul HTML și CSS e puțin mai separat, sunt încă în același fișier
-            și vom ajunge iar la
-            {' '}
-            <span className="text-bold">spaghetti code</span>
-            {' '}
-            pe măsură ce aplicația crește.
+            În practică însă,{' '}
+            <strong>nu recomandăm nici folosirea metodei interne</strong> pentru
+            că site-urile sunt construite din mai multe pagini deci vom ajunge
+            iar să facem copy-paste în fiecare pagină. Plus, deși codul HTML și
+            CSS e puțin mai separat, sunt încă în același fișier și vom ajunge
+            iar la <span className="text-bold">spaghetti code</span> pe măsură
+            ce aplicația crește.
           </p>
-          <p>
-            Și ajungem iar de unde am plecat, right?
-          </p>
+          <p>Și ajungem iar de unde am plecat, right?</p>
         </section>
         <section>
           <LessonHeading as="h3" id="css-extern">
@@ -284,26 +239,14 @@ export default function CssStylingLesson() {
           </LessonHeading>
           <p>
             Ei bine, acestea fiind zise care ar fi totuși soluția pentru a face
-            lucrurile așa cum trebuie? Metoda
-            {' '}
-            <strong>CSS-ului extern</strong>
-            {' '}
-            all the
-            way!
+            lucrurile așa cum trebuie? Metoda <strong>CSS-ului extern</strong>{' '}
+            all the way!
           </p>
           <p>
-            Aceasta este
-            {' '}
-            <strong>metoda pe care o recomandăm</strong>
-            {' '}
-            și constă în crearea unui
-            fișier separat pe care-l asociem paginilor HTML.
+            Aceasta este <strong>metoda pe care o recomandăm</strong> și constă
+            în crearea unui fișier separat pe care-l asociem paginilor HTML.
             Integrarea fișierului CSS în HTML se va face prin intermediul
-            elementului
-            {' '}
-            <strong className="formatted">{'<link>'}</strong>
-            {' '}
-            .
+            elementului <FormattedText as="strong">{'<link>'}</FormattedText> .
           </p>
           <Highlight
             className="my-5"
@@ -314,28 +257,19 @@ export default function CssStylingLesson() {
           <p>Unde:</p>
           <ul className="with--bullets">
             <li className="mb-4">
-              atributul
-              {' '}
-              <strong className="formatted">rel</strong>
-              {' '}
-              specifică
+              atributul <FormattedText as="strong">rel</FormattedText> specifică
               relația dintre documentul HTML curent și documentul extern pe care
               îl conectăm acesteia. În cazul nostru, documentul extern este o
               foaie de stil
             </li>
             <li>
-              atributul
-              {' '}
-              <strong className="formatted">href</strong>
-              {' '}
+              atributul <FormattedText as="strong">href</FormattedText>{' '}
               specifică locația (URL-ul) unde găsim foaia de stiluri
             </li>
           </ul>
           <p>
-            Mai concret,
-            {' '}
-            <span className="text-bold">hai să vedem un exemplu</span>
-            :
+            Mai concret,{' '}
+            <span className="text-bold">hai să vedem un exemplu</span>:
           </p>
           <BasicEditorLazy folderStructure={externCssExample} readOnly />
           <p>
@@ -348,23 +282,21 @@ export default function CssStylingLesson() {
             alt="Pagină web creata prin metoda CSS-ului extern"
             demo="/demo/css/css-extern"
           />
-          <p>
-            Prin această metodă rezolvăm ambele probleme:
-          </p>
+          <p>Prin această metodă rezolvăm ambele probleme:</p>
           <ul className="with--bullets">
             <li className="mb-4">
-              în ceea ce privește copy-paste'ul, avand un fisier
-              inclus in mai multe pagini e de ajuns sa modificam stilul
-              in acel fisier iar stilurile se vor aplica oriunde este inclus
+              în ceea ce privește copy-paste'ul, avand un fisier inclus in mai
+              multe pagini e de ajuns sa modificam stilul in acel fisier iar
+              stilurile se vor aplica oriunde este inclus
             </li>
             <li>
-              legat de spaghetti code, avand separat stilurile de HTML
-              e mult mai usor sa intelegem si sa modificam codul
+              legat de spaghetti code, avand separat stilurile de HTML e mult
+              mai usor sa intelegem si sa modificam codul
             </li>
           </ul>
           <LessonTip>
-            Psst: într-un document HTML pot fi adăugate mai multe foi de stil externe,
-            fiecare printr-un element link diferit.
+            Psst: într-un document HTML pot fi adăugate mai multe foi de stil
+            externe, fiecare printr-un element link diferit.
           </LessonTip>
         </section>
         <section>
@@ -372,31 +304,20 @@ export default function CssStylingLesson() {
             BONUS
           </LessonHeading>
           <p>
-            Poate v-ați întrebat de ce punem tagul
-            {' '}
-            <strong className="formatted">{'<link>'}</strong>
-            {' '}
-            in
-            {' '}
-            <strong className="formatted">{'<head>'}</strong>
-            {' '}
-            și nu în
-            {' '}
-            <strong className="formatted">{'<body>'}</strong>
-            {' '}
+            Poate v-ați întrebat de ce punem tagul{' '}
+            <FormattedText as="strong">{'<link>'}</FormattedText> in{' '}
+            <FormattedText as="strong">{'<head>'}</FormattedText> și nu în{' '}
+            <FormattedText as="strong">{'<body>'}</FormattedText>{' '}
           </p>
           <p>
             Motivul e legat de modul în care browser-ul citește documentul HTML,
-            și anume
-            {' '}
-            <strong>de sus în jos</strong>
-            {' '}
-            . Astfel, punând elementul înainte de body ne asigurăm
-            că stilurile sunt încărcate înainte să apară conținutul pe pagină.
+            și anume <strong>de sus în jos</strong> . Astfel, punând elementul
+            înainte de body ne asigurăm că stilurile sunt încărcate înainte să
+            apară conținutul pe pagină.
           </p>
           <p>
-            Dacă l-am pune la final de body - cum am făcut în video-ul de mai jos  - e posibil
-            să vedem mai întâi HTML-ul nestilizat iar mai târziu
+            Dacă l-am pune la final de body - cum am făcut în video-ul de mai
+            jos - e posibil să vedem mai întâi HTML-ul nestilizat iar mai târziu
             să se aplice stilurile.
           </p>
 
@@ -407,10 +328,8 @@ export default function CssStylingLesson() {
             alt="CSS extern inclus la final de body"
           />
           <LessonTip>
-            De aceea ca și "good practice" vom includem fișierele
-            de CSS externe în
-            {' '}
-            <span className="formatted">{'<head>'}</span>
+            De aceea ca și "good practice" vom includem fișierele de CSS externe
+            în <FormattedText as="span">{'<head>'}</FormattedText>
           </LessonTip>
         </section>
       </Lesson>
@@ -419,25 +338,28 @@ export default function CssStylingLesson() {
 }
 
 const externCssExample: {
-  folders: ExerciseFolder[],
-  files: ExerciseFile[]
+  folders: ExerciseFolder[];
+  files: ExerciseFile[];
 } = {
-  folders: [{
-    key: 'style',
-    name: 'style',
-    files: [{
-      key: 'custom.css',
-      name: 'custom.css',
-      content: `body {
+  folders: [
+    {
+      key: 'style',
+      name: 'style',
+      files: [
+        {
+          key: 'custom.css',
+          name: 'custom.css',
+          content: `body {
   color: #fff;
   text-align: center;
   font-family: sans-serif;
   background-color: #282a36;
 }`,
-    }, {
-      key: 'style.css',
-      name: 'style.css',
-      content: `h1 {
+        },
+        {
+          key: 'style.css',
+          name: 'style.css',
+          content: `h1 {
   text-align: center;
   font-size: 40px;
   text-decoration: underline;
@@ -453,13 +375,16 @@ p {
   margin-left: 50px;
 }
 `,
-    }],
-    folders: [],
-  }],
-  files: [{
-    key: 'index.html',
-    name: 'index.html',
-    content: `<!DOCTYPE html>
+        },
+      ],
+      folders: [],
+    },
+  ],
+  files: [
+    {
+      key: 'index.html',
+      name: 'index.html',
+      content: `<!DOCTYPE html>
 <html>
 <head>
   <title>My Dog</title>
@@ -473,5 +398,6 @@ p {
 </body>
 </html>
 `,
-  }],
+    },
+  ],
 };

--- a/client/curriculum/css/StylingMethods.tsx
+++ b/client/curriculum/css/StylingMethods.tsx
@@ -51,8 +51,16 @@ export default function CssStylingLesson() {
         </LessonCover>
         <p>
           În acest articol vom vorbi despre cele trei modalități prin care putem
-          aplica stilul unei pagini web: <strong>CSS inline</strong>,{' '}
-          <strong>CSS intern</strong> sau <strong>CSS extern</strong>. Fiecare
+          aplica stilul unei pagini web:
+          {' '}
+          <strong>CSS inline</strong>
+          ,
+          {' '}
+          <strong>CSS intern</strong>
+          {' '}
+          sau
+          <strong>CSS extern</strong>
+          . Fiecare
           metoda vine cu avantaje și dezavantaje, despre care vom vorbi în cele
           ce urmează.
         </p>
@@ -61,12 +69,19 @@ export default function CssStylingLesson() {
             CSS inline
           </LessonHeading>
           <p>
-            Prin <FormattedText as="strong">CSS inline</FormattedText> putem
+            Prin
+            {' '}
+            <FormattedText as="strong">CSS inline</FormattedText>
+            {' '}
+            putem
             aplica stilul unui singur element HTML.
           </p>
           <p>
-            Scrierea codului CSS se va face prin adaugarea atributului{' '}
-            <FormattedText as="strong">style</FormattedText> pe elementul căruia
+            Scrierea codului CSS se va face prin adaugarea atributului
+            {' '}
+            <FormattedText as="strong">style</FormattedText>
+            {' '}
+            pe elementul căruia
             vrem să-i modificăm stilul:
           </p>
           <Highlight
@@ -96,7 +111,10 @@ export default function CssStylingLesson() {
             demo="/demo/css/css-inline"
           />
           <p>
-            Metoda inline vine la pachet cu <strong>dezavantaje uriașe</strong>{' '}
+            Metoda inline vine la pachet cu
+            {' '}
+            <strong>dezavantaje uriașe</strong>
+            {' '}
             și din această cauză majoritatea programatorilor o evită. Hai să
             vedem de ce nu e indicată:
           </p>
@@ -110,7 +128,9 @@ export default function CssStylingLesson() {
             </li>
             <li>
               vedem că e greu să distingem codul CSS de cel HTML (se produce un
-              așa numit efect de <strong>spaghetti code</strong>
+              așa numit efect de
+              {' '}
+              <strong>spaghetti code</strong>
               ). Așadar, ne va fi dificil să înțelegem și să facem modificări pe
               un astfel de cod.
             </li>
@@ -127,15 +147,25 @@ export default function CssStylingLesson() {
           </LessonHeading>
           <p>
             Dacă prin metoda inline trebuie să stilizăm câte un element pe rând,
-            printr-un <strong>CSS intern</strong> putem controla stilul pentru o
+            printr-un
+            {' '}
+            <strong>CSS intern</strong>
+            {' '}
+            putem controla stilul pentru o
             întreagă pagină, scăpând astfel de codul duplicat. Totodată, vom
             avea o mai bună înțelegere a codului și vom câștiga timp.
           </p>
           <p>
             Metoda de integrare a codului CSS în pagina web se va face prin
-            inserarea elementului{' '}
-            <FormattedText as="strong">{'<style>'}</FormattedText> în secțiunea{' '}
-            <FormattedText as="strong">{'<head>'}</FormattedText> a documentului
+            inserarea elementului
+            {' '}
+            <FormattedText as="strong">{'<style>'}</FormattedText>
+            {' '}
+            în secțiunea
+            {' '}
+            <FormattedText as="strong">{'<head>'}</FormattedText>
+            {' '}
+            a documentului
             HTML. Față de metoda anterioară, la aceasta trebuie să precizăm
             pentru ce elemente vom aplica regulile de stilizare.
           </p>
@@ -152,8 +182,11 @@ export default function CssStylingLesson() {
 </style>`}
           />
           <p>
-            În exemplul de mai sus aplicăm regulile pe toate elementele de tip{' '}
-            <FormattedText as="strong">a</FormattedText> , selectorul folosit
+            În exemplul de mai sus aplicăm regulile pe toate elementele de tip
+            {' '}
+            <FormattedText as="strong">a</FormattedText>
+            {' '}
+            , selectorul folosit
             fiind tagul elementului HTML.
           </p>
           <LessonTip>
@@ -223,12 +256,18 @@ export default function CssStylingLesson() {
             CSS ceea ce e o îmbunătățire față de metoda anterioară.
           </p>
           <p>
-            În practică însă,{' '}
-            <strong>nu recomandăm nici folosirea metodei interne</strong> pentru
+            În practică însă,
+            {' '}
+            <strong>nu recomandăm nici folosirea metodei interne</strong>
+            {' '}
+            pentru
             că site-urile sunt construite din mai multe pagini deci vom ajunge
             iar să facem copy-paste în fiecare pagină. Plus, deși codul HTML și
             CSS e puțin mai separat, sunt încă în același fișier și vom ajunge
-            iar la <span className="text-bold">spaghetti code</span> pe măsură
+            iar la
+            <span className="text-bold">spaghetti code</span>
+            {' '}
+            pe măsură
             ce aplicația crește.
           </p>
           <p>Și ajungem iar de unde am plecat, right?</p>
@@ -239,14 +278,25 @@ export default function CssStylingLesson() {
           </LessonHeading>
           <p>
             Ei bine, acestea fiind zise care ar fi totuși soluția pentru a face
-            lucrurile așa cum trebuie? Metoda <strong>CSS-ului extern</strong>{' '}
+            lucrurile așa cum trebuie? Metoda
+            {' '}
+            <strong>CSS-ului extern</strong>
+            {' '}
             all the way!
           </p>
           <p>
-            Aceasta este <strong>metoda pe care o recomandăm</strong> și constă
+            Aceasta este
+            {' '}
+            <strong>metoda pe care o recomandăm</strong>
+            {' '}
+            și constă
             în crearea unui fișier separat pe care-l asociem paginilor HTML.
             Integrarea fișierului CSS în HTML se va face prin intermediul
-            elementului <FormattedText as="strong">{'<link>'}</FormattedText> .
+            elementului
+            {' '}
+            <FormattedText as="strong">{'<link>'}</FormattedText>
+            {' '}
+            .
           </p>
           <Highlight
             className="my-5"
@@ -257,19 +307,28 @@ export default function CssStylingLesson() {
           <p>Unde:</p>
           <ul className="with--bullets">
             <li className="mb-4">
-              atributul <FormattedText as="strong">rel</FormattedText> specifică
+              atributul
+              {' '}
+              <FormattedText as="strong">rel</FormattedText>
+              {' '}
+              specifică
               relația dintre documentul HTML curent și documentul extern pe care
               îl conectăm acesteia. În cazul nostru, documentul extern este o
               foaie de stil
             </li>
             <li>
-              atributul <FormattedText as="strong">href</FormattedText>{' '}
+              atributul
+              {' '}
+              <FormattedText as="strong">href</FormattedText>
+              {' '}
               specifică locația (URL-ul) unde găsim foaia de stiluri
             </li>
           </ul>
           <p>
-            Mai concret,{' '}
-            <span className="text-bold">hai să vedem un exemplu</span>:
+            Mai concret,
+            {' '}
+            <span className="text-bold">hai să vedem un exemplu</span>
+            :
           </p>
           <BasicEditorLazy folderStructure={externCssExample} readOnly />
           <p>
@@ -304,14 +363,26 @@ export default function CssStylingLesson() {
             BONUS
           </LessonHeading>
           <p>
-            Poate v-ați întrebat de ce punem tagul{' '}
-            <FormattedText as="strong">{'<link>'}</FormattedText> in{' '}
-            <FormattedText as="strong">{'<head>'}</FormattedText> și nu în{' '}
-            <FormattedText as="strong">{'<body>'}</FormattedText>{' '}
+            Poate v-ați întrebat de ce punem tagul
+            {' '}
+            <FormattedText as="strong">{'<link>'}</FormattedText>
+            {' '}
+            in
+            {' '}
+            <FormattedText as="strong">{'<head>'}</FormattedText>
+            {' '}
+            și nu în
+            {' '}
+            <FormattedText as="strong">{'<body>'}</FormattedText>
+            {' '}
           </p>
           <p>
             Motivul e legat de modul în care browser-ul citește documentul HTML,
-            și anume <strong>de sus în jos</strong> . Astfel, punând elementul
+            și anume
+            {' '}
+            <strong>de sus în jos</strong>
+            {' '}
+            . Astfel, punând elementul
             înainte de body ne asigurăm că stilurile sunt încărcate înainte să
             apară conținutul pe pagină.
           </p>
@@ -329,7 +400,9 @@ export default function CssStylingLesson() {
           />
           <LessonTip>
             De aceea ca și "good practice" vom includem fișierele de CSS externe
-            în <FormattedText as="span">{'<head>'}</FormattedText>
+            în
+            {' '}
+            <FormattedText as="span">{'<head>'}</FormattedText>
           </LessonTip>
         </section>
       </Lesson>

--- a/client/curriculum/html/AudioAndVideo.tsx
+++ b/client/curriculum/html/AudioAndVideo.tsx
@@ -64,10 +64,16 @@ export default function VideoAndAudioLesson() {
             {'Elementul <audio>'}
           </LessonHeading>
           <p>
-            Elementul <FormattedText as="strong">{'<audio>'}</FormattedText>{' '}
+            Elementul
+            {' '}
+            <FormattedText as="strong">{'<audio>'}</FormattedText>
+            {' '}
             este folosit pentru a adăuga fișiere audio paginii tale web.
             Următorul exemplu arată o simplă utilizare a lui, cu ajutorul
-            atributului <FormattedText as="strong">src</FormattedText>:
+            atributului
+            {' '}
+            <FormattedText as="strong">src</FormattedText>
+            :
           </p>
           <Highlight
             className="my-5"
@@ -77,13 +83,24 @@ export default function VideoAndAudioLesson() {
 `}
           />
           <p>
-            O altă metodă de a declara{' '}
-            <FormattedText as="strong">{'<audio>'}</FormattedText> este folosind
-            două sau mai multe elemente{' '}
-            <FormattedText as="strong">{'<source>'}</FormattedText>. Fiecare
-            astfel de element va trebui să conțină atributul{' '}
-            <FormattedText as="strong">src</FormattedText> împreună cu atributul{' '}
-            <FormattedText as="strong">type</FormattedText> pentru a specifica
+            O altă metodă de a declara
+            {' '}
+            <FormattedText as="strong">{'<audio>'}</FormattedText>
+            {' '}
+            este folosind
+            două sau mai multe elemente
+            {' '}
+            <FormattedText as="strong">{'<source>'}</FormattedText>
+            . Fiecare
+            astfel de element va trebui să conțină atributul
+            {' '}
+            <FormattedText as="strong">src</FormattedText>
+            {' '}
+            împreună cu atributul
+            {' '}
+            <FormattedText as="strong">type</FormattedText>
+            {' '}
+            pentru a specifica
             formatul fișierului.
           </p>
           <LessonTip>
@@ -124,7 +141,8 @@ export default function VideoAndAudioLesson() {
               />
 
               <p>
-                Browser-ul tău nu suportă fișiere audio. Folosește{' '}
+                Browser-ul tău nu suportă fișiere audio. Folosește
+                {' '}
                 <a
                   href={`${process.env.CLOUDFRONT_PUBLIC}/demo-assets/audio-video/big-buck-bunny-audio.mp3`}
                 >
@@ -140,7 +158,11 @@ export default function VideoAndAudioLesson() {
             </Link>
           </DemoPreview>
           <p>
-            Elementul <FormattedText as="strong">{'<p>'}</FormattedText> din
+            Elementul
+            {' '}
+            <FormattedText as="strong">{'<p>'}</FormattedText>
+            {' '}
+            din
             exemplul de mai sus, are rolul de fallback, acesta va fi afișat în
             cazul în care browser-ul nu suportă nici unul dintre formatele
             specificate.
@@ -152,15 +174,22 @@ export default function VideoAndAudioLesson() {
           </LessonHeading>
           <ul className="with--bullets">
             <li className="mb-4">
-              <FormattedText as="strong">src</FormattedText> – indică locația
-              fișierului audio{' '}
+              <FormattedText as="strong">src</FormattedText>
+              {' '}
+              – indică locația
+              fișierului audio
+              {' '}
             </li>
             <li className="mb-4">
-              <FormattedText as="strong">type</FormattedText> – specifică tipul
+              <FormattedText as="strong">type</FormattedText>
+              {' '}
+              – specifică tipul
               fișierului audio
             </li>
             <li className="mb-4">
-              <FormattedText as="strong">controls</FormattedText> – dacă acest
+              <FormattedText as="strong">controls</FormattedText>
+              {' '}
+              – dacă acest
               atribut este prezent, browser-ul va oferi funcții pentru a permite
               user-ului să dea play/pause, să controleze volumul, etc
             </li>
@@ -183,8 +212,11 @@ export default function VideoAndAudioLesson() {
 `}
           />
           <LessonTip>
-            Nu uita că ordinea elementelor{' '}
-            <FormattedText as="strong">{'<source>'}</FormattedText> este extrem
+            Nu uita că ordinea elementelor
+            {' '}
+            <FormattedText as="strong">{'<source>'}</FormattedText>
+            {' '}
+            este extrem
             de importantă căci browserul le va parcurge de sus în jos și o va
             alege pe prima compatibilă.
           </LessonTip>
@@ -194,10 +226,16 @@ export default function VideoAndAudioLesson() {
             {'Elementul <video>'}
           </LessonHeading>
           <p>
-            Elementul <FormattedText as="strong">{'<video>'}</FormattedText> ne
+            Elementul
+            {' '}
+            <FormattedText as="strong">{'<video>'}</FormattedText>
+            {' '}
+            ne
             permite adăugarea unui video pe pagina noastră. Cel mai simplu mod
-            de utilizare este - similar ca la audio - prin atributul{' '}
-            <FormattedText as="strong">src</FormattedText>.
+            de utilizare este - similar ca la audio - prin atributul
+            {' '}
+            <FormattedText as="strong">src</FormattedText>
+            .
           </p>
           <Highlight
             className="my-5"
@@ -207,9 +245,13 @@ export default function VideoAndAudioLesson() {
 `}
           />
           <p>
-            <strong>La fel ca si la audio</strong>, putem specifica mai multe
-            surse ale clipului video folosind tagul{' '}
-            <FormattedText as="strong">{'<source>'}</FormattedText> :
+            <strong>La fel ca si la audio</strong>
+            , putem specifica mai multe
+            surse ale clipului video folosind tagul
+            {' '}
+            <FormattedText as="strong">{'<source>'}</FormattedText>
+            {' '}
+            :
           </p>
           <Highlight
             className="my-5"
@@ -241,34 +283,51 @@ export default function VideoAndAudioLesson() {
             {'Atributele principale elementului <video>'}
           </LessonHeading>
           <p>
-            Trebuie să știi că toate{' '}
+            Trebuie să știi că toate
+            {' '}
             <a href="#atributele-elementului-audio">
               atributele elementului audio
-            </a>{' '}
-            menționate mai sus sunt{' '}
-            <strong>valabile și pentru clipuri video</strong>. Pe lângă acestea,
+            </a>
+            {' '}
+            menționate mai sus sunt
+            {' '}
+            <strong>valabile și pentru clipuri video</strong>
+            . Pe lângă acestea,
             unui video putem să-i specificăm și:
           </p>
           <ul className="with--bullets">
             <li className="mb-4">
               {' '}
-              <FormattedText as="strong">width</FormattedText> – specifica
-              lățimea playerului video exprimată în pixeli;{' '}
+              <FormattedText as="strong">width</FormattedText>
+              {' '}
+              – specifica
+              lățimea playerului video exprimată în pixeli;
+              {' '}
             </li>
             <li className="mb-4">
               {' '}
-              <FormattedText as="strong">height</FormattedText> – specifica
-              înălțimea playerului video exprimată în pixeli;{' '}
+              <FormattedText as="strong">height</FormattedText>
+              {' '}
+              – specifica
+              înălțimea playerului video exprimată în pixeli;
+              {' '}
             </li>
             <li className="mb-4">
               {' '}
-              <FormattedText as="strong">muted</FormattedText> – prin acest
+              <FormattedText as="strong">muted</FormattedText>
+              {' '}
+              – prin acest
               atribut browser-ul va initializa clipul audio cu volum 0. Acesta
-              poate fi schimbat de utilizator daca atributul{' '}
-              <FormattedText as="span">controls</FormattedText> este specificat
+              poate fi schimbat de utilizator daca atributul
+              {' '}
+              <FormattedText as="span">controls</FormattedText>
+              {' '}
+              este specificat
             </li>
             <li>
-              <FormattedText as="strong">autoplay</FormattedText> – dacă acest
+              <FormattedText as="strong">autoplay</FormattedText>
+              {' '}
+              – dacă acest
               atribut este prezent, browser-ul va da "play" la audio imediat ce
               acesta este încărcat în pagină
             </li>

--- a/client/curriculum/html/AudioAndVideo.tsx
+++ b/client/curriculum/html/AudioAndVideo.tsx
@@ -14,13 +14,20 @@ import Highlight from '~/components/Highlight/Highlight';
 import { DemoPreview } from '~/components/demo';
 
 import coverSvg from '~/public/images/lessons/audio-and-video__cover.svg';
+import FormattedText from '~/components/FormattedText';
 
 const contributors = [SebastianLatkolic];
 const chapters = [
   { title: 'Elementul <audio>', id: 'audio-element' },
-  { title: 'Atributele elementului <audio>', id: 'atributele-elementului-audio' },
+  {
+    title: 'Atributele elementului <audio>',
+    id: 'atributele-elementului-audio',
+  },
   { title: 'Elementul <video>', id: 'video-element' },
-  { title: 'Atributele elementului <video>', id: 'atributele-elementului-video' },
+  {
+    title: 'Atributele elementului <video>',
+    id: 'atributele-elementului-video',
+  },
   { title: 'Exerciții', id: 'exercitii' },
 ];
 
@@ -57,16 +64,10 @@ export default function VideoAndAudioLesson() {
             {'Elementul <audio>'}
           </LessonHeading>
           <p>
-            Elementul
-            {' '}
-            <strong className="formatted">{'<audio>'}</strong>
-            {' '}
-            este
-            folosit pentru a adăuga fișiere audio paginii tale web. Următorul
-            exemplu arată o simplă utilizare a lui, cu ajutorul atributului
-            {' '}
-            <strong className="formatted">src</strong>
-            :
+            Elementul <FormattedText as="strong">{'<audio>'}</FormattedText>{' '}
+            este folosit pentru a adăuga fișiere audio paginii tale web.
+            Următorul exemplu arată o simplă utilizare a lui, cu ajutorul
+            atributului <FormattedText as="strong">src</FormattedText>:
           </p>
           <Highlight
             className="my-5"
@@ -76,27 +77,19 @@ export default function VideoAndAudioLesson() {
 `}
           />
           <p>
-            O altă metodă de a declara
-            {' '}
-            <strong className="formatted">{'<audio>'}</strong>
-            {' '}
-            este folosind două sau mai multe elemente
-            {' '}
-            <strong className="formatted">{'<source>'}</strong>
-            . Fiecare astfel de element va trebui să conțină atributul
-            {' '}
-            <strong className="formatted">src</strong>
-            {' '}
-            împreună cu atributul
-            {' '}
-            <strong className="formatted">type</strong>
-            {' '}
-            pentru a specifica formatul fișierului.
+            O altă metodă de a declara{' '}
+            <FormattedText as="strong">{'<audio>'}</FormattedText> este folosind
+            două sau mai multe elemente{' '}
+            <FormattedText as="strong">{'<source>'}</FormattedText>. Fiecare
+            astfel de element va trebui să conțină atributul{' '}
+            <FormattedText as="strong">src</FormattedText> împreună cu atributul{' '}
+            <FormattedText as="strong">type</FormattedText> pentru a specifica
+            formatul fișierului.
           </p>
           <LessonTip>
             Nu toate browserele suportă fiecare tip de fișier audio, de aceea
-            este recomandat să oferim mai multe formate diferite (mp3, ogg, etc), iar
-            browser-ul o va alege pe prima compatibilă.
+            este recomandat să oferim mai multe formate diferite (mp3, ogg,
+            etc), iar browser-ul o va alege pe prima compatibilă.
           </LessonTip>
           <Highlight
             className="my-5"
@@ -115,7 +108,11 @@ export default function VideoAndAudioLesson() {
           />
           <DemoPreview>
             {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-            <audio style={{ border: '1px solid #000' }} controls className="mb-2">
+            <audio
+              style={{ border: '1px solid #000' }}
+              controls
+              className="mb-2"
+            >
               <source
                 src={`${process.env.CLOUDFRONT_PUBLIC}/demo-assets/audio-video/big-buck-bunny-audio.mp3`}
                 type="audio/mpeg"
@@ -127,10 +124,12 @@ export default function VideoAndAudioLesson() {
               />
 
               <p>
-                Browser-ul tău nu suportă fișiere audio.
-                Folosește
-                {' '}
-                <a href={`${process.env.CLOUDFRONT_PUBLIC}/demo-assets/audio-video/big-buck-bunny-audio.mp3`}>acest link</a>
+                Browser-ul tău nu suportă fișiere audio. Folosește{' '}
+                <a
+                  href={`${process.env.CLOUDFRONT_PUBLIC}/demo-assets/audio-video/big-buck-bunny-audio.mp3`}
+                >
+                  acest link
+                </a>
                 pentru a-l putea vizualiza.
               </p>
             </audio>
@@ -141,15 +140,11 @@ export default function VideoAndAudioLesson() {
             </Link>
           </DemoPreview>
           <p>
-            Elementul
-            {' '}
-            <strong className="formatted">{'<p>'}</strong>
-            {' '}
-            din
+            Elementul <FormattedText as="strong">{'<p>'}</FormattedText> din
             exemplul de mai sus, are rolul de fallback, acesta va fi afișat în
-            cazul în care browser-ul nu suportă nici unul dintre formatele specificate.
+            cazul în care browser-ul nu suportă nici unul dintre formatele
+            specificate.
           </p>
-
         </section>
         <section>
           <LessonHeading as="h3" id="atributele-elementului-audio">
@@ -157,22 +152,15 @@ export default function VideoAndAudioLesson() {
           </LessonHeading>
           <ul className="with--bullets">
             <li className="mb-4">
-              <strong className="formatted">src</strong>
-              {' '}
-              – indică locația
-              fișierului audio
-              {' '}
+              <FormattedText as="strong">src</FormattedText> – indică locația
+              fișierului audio{' '}
             </li>
             <li className="mb-4">
-              <strong className="formatted">type</strong>
-              {' '}
-              – specifică tipul
+              <FormattedText as="strong">type</FormattedText> – specifică tipul
               fișierului audio
             </li>
             <li className="mb-4">
-              <strong className="formatted">controls</strong>
-              {' '}
-              – dacă acest
+              <FormattedText as="strong">controls</FormattedText> – dacă acest
               atribut este prezent, browser-ul va oferi funcții pentru a permite
               user-ului să dea play/pause, să controleze volumul, etc
             </li>
@@ -195,13 +183,10 @@ export default function VideoAndAudioLesson() {
 `}
           />
           <LessonTip>
-            Nu uita că ordinea elementelor
-            {' '}
-            <strong className="formatted">{'<source>'}</strong>
-            {' '}
-            este extrem de
-            importantă căci browserul le va parcurge de sus în jos și o va alege
-            pe prima compatibilă.
+            Nu uita că ordinea elementelor{' '}
+            <FormattedText as="strong">{'<source>'}</FormattedText> este extrem
+            de importantă căci browserul le va parcurge de sus în jos și o va
+            alege pe prima compatibilă.
           </LessonTip>
         </section>
         <section>
@@ -209,16 +194,10 @@ export default function VideoAndAudioLesson() {
             {'Elementul <video>'}
           </LessonHeading>
           <p>
-            Elementul
-            {' '}
-            <strong className="formatted">{'<video>'}</strong>
-            {' '}
-            ne
+            Elementul <FormattedText as="strong">{'<video>'}</FormattedText> ne
             permite adăugarea unui video pe pagina noastră. Cel mai simplu mod
-            de utilizare este - similar ca la audio - prin atributul
-            {' '}
-            <strong className="formatted">src</strong>
-            .
+            de utilizare este - similar ca la audio - prin atributul{' '}
+            <FormattedText as="strong">src</FormattedText>.
           </p>
           <Highlight
             className="my-5"
@@ -228,13 +207,9 @@ export default function VideoAndAudioLesson() {
 `}
           />
           <p>
-            <strong>La fel ca si la audio</strong>
-            , putem specifica mai multe surse ale
-            clipului video folosind tagul
-            {' '}
-            <strong className="formatted">{'<source>'}</strong>
-            {' '}
-            :
+            <strong>La fel ca si la audio</strong>, putem specifica mai multe
+            surse ale clipului video folosind tagul{' '}
+            <FormattedText as="strong">{'<source>'}</FormattedText> :
           </p>
           <Highlight
             className="my-5"
@@ -266,52 +241,36 @@ export default function VideoAndAudioLesson() {
             {'Atributele principale elementului <video>'}
           </LessonHeading>
           <p>
-            Trebuie să știi că toate
-            {' '}
+            Trebuie să știi că toate{' '}
             <a href="#atributele-elementului-audio">
               atributele elementului audio
-            </a>
-            {' '}
-            menționate mai sus sunt
-            {' '}
-            <strong>valabile și pentru clipuri video</strong>
-            .
-            Pe lângă acestea, unui video putem să-i specificăm și:
+            </a>{' '}
+            menționate mai sus sunt{' '}
+            <strong>valabile și pentru clipuri video</strong>. Pe lângă acestea,
+            unui video putem să-i specificăm și:
           </p>
           <ul className="with--bullets">
             <li className="mb-4">
               {' '}
-              <strong className="formatted">width</strong>
-              {' '}
-              – specifica lățimea
-              playerului video exprimată în pixeli;
-              {' '}
+              <FormattedText as="strong">width</FormattedText> – specifica
+              lățimea playerului video exprimată în pixeli;{' '}
             </li>
             <li className="mb-4">
               {' '}
-              <strong className="formatted">height</strong>
-              {' '}
-              – specifica
-              înălțimea playerului video exprimată în pixeli;
-              {' '}
+              <FormattedText as="strong">height</FormattedText> – specifica
+              înălțimea playerului video exprimată în pixeli;{' '}
             </li>
             <li className="mb-4">
               {' '}
-              <strong className="formatted">muted</strong>
-              {' '}
-              – prin acest atribut browser-ul va initializa clipul audio
-              cu volum 0. Acesta poate fi schimbat de utilizator daca atributul
-              {' '}
-              <span className="formatted">controls</span>
-              {' '}
-              este specificat
+              <FormattedText as="strong">muted</FormattedText> – prin acest
+              atribut browser-ul va initializa clipul audio cu volum 0. Acesta
+              poate fi schimbat de utilizator daca atributul{' '}
+              <FormattedText as="span">controls</FormattedText> este specificat
             </li>
             <li>
-              <strong className="formatted">autoplay</strong>
-              {' '}
-              – dacă acest
-              atribut este prezent, browser-ul va da "play" la audio imediat
-              ce acesta este încărcat în pagină
+              <FormattedText as="strong">autoplay</FormattedText> – dacă acest
+              atribut este prezent, browser-ul va da "play" la audio imediat ce
+              acesta este încărcat în pagină
             </li>
           </ul>
           <Highlight

--- a/client/curriculum/html/HTMLStructure/HTMLStructure.tsx
+++ b/client/curriculum/html/HTMLStructure/HTMLStructure.tsx
@@ -69,22 +69,34 @@ function HTMLStructure() {
               <p className="mb-4">
                 {' '}
                 Fiecare pagină web este alcătuită din următoarele elemente
-                principale:{' '}
+                principale:
+                {' '}
               </p>
               <ol className="with--checkmark">
                 <li className="mb-4">
-                  <FormattedText as="strong">{'<!DOCTYPE html>'}</FormattedText>{' '}
+                  <FormattedText as="strong">{'<!DOCTYPE html>'}</FormattedText>
+                  {' '}
                   îi specifică browserului că acest document este de tipul HTML
                 </li>
                 <li className="mb-4">
-                  <FormattedText as="strong">{'<html>'}</FormattedText> este
+                  <FormattedText as="strong">{'<html>'}</FormattedText>
+                  {' '}
+                  este
                   elementul părinte al fiecărei pagini
                 </li>
                 <li className="mb-4">
-                  <FormattedText as="strong">{'<head>'}</FormattedText> și{' '}
-                  <FormattedText as="strong">{'<body>'}</FormattedText> sunt
-                  descendenți ai elementului{' '}
-                  <FormattedText as="strong">{'<html>'}</FormattedText> și vor
+                  <FormattedText as="strong">{'<head>'}</FormattedText>
+                  {' '}
+                  și
+                  {' '}
+                  <FormattedText as="strong">{'<body>'}</FormattedText>
+                  {' '}
+                  sunt
+                  descendenți ai elementului
+                  {' '}
+                  <FormattedText as="strong">{'<html>'}</FormattedText>
+                  {' '}
+                  și vor
                   fi definiți o singură dată
                 </li>
               </ol>
@@ -114,7 +126,11 @@ function HTMLStructure() {
             {'Elementul <head>'}
           </LessonHeading>
           <p>
-            În <FormattedText as="strong">{'<head>'}</FormattedText> vom
+            În
+            {' '}
+            <FormattedText as="strong">{'<head>'}</FormattedText>
+            {' '}
+            vom
             introduce elemente ce ne descriu website-ul, precum:
           </p>
           <ul className="with--bullets">
@@ -140,9 +156,11 @@ function HTMLStructure() {
             `}
           />
           <p>
-            <strong>Titlul va apărea în tabul browserului</strong>, iar împreuna
+            <strong>Titlul va apărea în tabul browserului</strong>
+            , iar împreuna
             cu descrierea le vom vedea și în
-            <strong>motoarele de căutare</strong>. Spre exemplu, uite cum arată
+            <strong>motoarele de căutare</strong>
+            . Spre exemplu, uite cum arată
             site-ul nostru în urma unei căutări pe Google:
           </p>
           <LessonFigure
@@ -151,8 +169,11 @@ function HTMLStructure() {
             src={`${process.env.CLOUDFRONT_PUBLIC}/public/images/lessons/html-structure/frontend-ro-google-search.png`}
           />
           <p>
-            Mai mult, via taguri{' '}
-            <FormattedText as="strong">{'<meta>'}</FormattedText> putem controla
+            Mai mult, via taguri
+            {' '}
+            <FormattedText as="strong">{'<meta>'}</FormattedText>
+            {' '}
+            putem controla
             cum apare site-ul când e distribuit pe rețele sociale precum
             Facebook, LinkedIn etc. Adică noi ca și programatori alegem ce
             imagine, titlu și descriere vor vedea utilizatorii acestor site-uri:
@@ -169,7 +190,9 @@ function HTMLStructure() {
           />
           <p>
             Ca să obținem rezultatul de mai sus, am folosit următoarele taguri
-            în <FormattedText as="strong">{'<head>'}</FormattedText>
+            în
+            {' '}
+            <FormattedText as="strong">{'<head>'}</FormattedText>
           </p>
           <Highlight
             className="my-5"
@@ -193,15 +216,26 @@ function HTMLStructure() {
 <meta property="og:image:height" content="630" />`}
           />
           <LessonTip>
-            Valorile pentru{' '}
-            <FormattedText as="strong">property=""</FormattedText> și{' '}
-            <FormattedText as="strong">content=""</FormattedText> din codul de
-            mai sus sunt specifice standardului{' '}
-            <a href="https://ogp.me/">Open Graph</a>.
+            Valorile pentru
+            {' '}
+            <FormattedText as="strong">property=""</FormattedText>
+            {' '}
+            și
+            {' '}
+            <FormattedText as="strong">content=""</FormattedText>
+            {' '}
+            din codul de
+            mai sus sunt specifice standardului
+            {' '}
+            <a href="https://ogp.me/">Open Graph</a>
+            .
           </LessonTip>
           <p className="my-5">
-            Dar asta nu e tot. În{' '}
-            <FormattedText as="strong">{'<head>'}</FormattedText> vom adăuga și
+            Dar asta nu e tot. În
+            {' '}
+            <FormattedText as="strong">{'<head>'}</FormattedText>
+            {' '}
+            vom adăuga și
             linkuri spre alte resurse folosite de site-ul nostru. De exemplu:
             foi de stiluri CSS, fișiere JavaScript etc.
           </p>
@@ -215,9 +249,14 @@ function HTMLStructure() {
 `}
           />
           <LessonTip>
-            Nu uita că poți să vezi codul oricărui website prin{' '}
+            Nu uita că poți să vezi codul oricărui website prin
+            {' '}
             <FormattedText as="strong">
-              Click Dreapta {'->'} View Page Source
+              Click Dreapta
+              {' '}
+              {'->'}
+              {' '}
+              View Page Source
             </FormattedText>
           </LessonTip>
         </section>
@@ -227,7 +266,8 @@ function HTMLStructure() {
           </LessonHeading>
           <p>
             De la sine prin denumirea lui, elementul body (trupul) este
-            responsabil pentru{' '}
+            responsabil pentru
+            {' '}
             <strong>
               conținutul care-l vedem și cu care interacționăm efectiv în
               website
@@ -275,12 +315,17 @@ function HTMLStructure() {
             Rezumat
           </LessonHeading>
           <p>
-            În <FormattedText as="strong">{'<head>'}</FormattedText> adăugam
+            În
+            {' '}
+            <FormattedText as="strong">{'<head>'}</FormattedText>
+            {' '}
+            adăugam
             două tipuri de elemente:
           </p>
           <ul className="with--bullets">
             <li>
-              <strong>Elemente descriptive</strong>, care ne dau informații
+              <strong>Elemente descriptive</strong>
+              , care ne dau informații
               despre site/aplicație și sunt utile pentru SEO (search engine
               optimiation), inclusiv rețelele sociale
             </li>
@@ -291,7 +336,11 @@ function HTMLStructure() {
             </li>
           </ul>
           <p>
-            În <FormattedText as="strong">{'<body>'}</FormattedText> adăugăm
+            În
+            {' '}
+            <FormattedText as="strong">{'<body>'}</FormattedText>
+            {' '}
+            adăugăm
             elementele ce fac parte efectiv din site-ul nostru, și cu care vor
             interacționa utilizatorii. Aproape toate elementele HTML (cu câteva
             excepții) vor fi adăugate aici.
@@ -329,7 +378,7 @@ const ResponsiveFlex = React.forwardRef<HTMLDivElement, ResponsiveFlexProps>(
         {children}
       </div>
     );
-  }
+  },
 );
 
 export default HTMLStructure;

--- a/client/curriculum/html/HTMLStructure/HTMLStructure.tsx
+++ b/client/curriculum/html/HTMLStructure/HTMLStructure.tsx
@@ -12,6 +12,7 @@ import { getLessonById } from '~/services/Constants';
 import Highlight from '~/components/Highlight/Highlight';
 import { Pava, IulianRedinciuc } from '~/services/contributors';
 import SideBySidePictures from '~/components/SideBySidePictures';
+import FormattedText from '~/components/FormattedText';
 
 import styles from './HTMLStructure.module.scss';
 
@@ -35,9 +36,18 @@ function HTMLStructure() {
         url={`https://FrontEnd.ro/${lessonInfo.url}`}
         shareImage={`${process.env.CLOUDFRONT_PUBLIC}/seo/html-structure_1200w.jpg`}
       >
-        <link rel="preload" as="image" href={`${process.env.CLOUDFRONT_PUBLIC}/seo/html-structure_1200w.jpg`} />
+        <link
+          rel="preload"
+          as="image"
+          href={`${process.env.CLOUDFRONT_PUBLIC}/seo/html-structure_1200w.jpg`}
+        />
       </SEOTags>
-      <Lesson id={lessonId} title={lessonInfo.title} chapters={chapters} withExercises={false}>
+      <Lesson
+        id={lessonId}
+        title={lessonInfo.title}
+        chapters={chapters}
+        withExercises={false}
+      >
         <LessonContributors className="absolute" contributors={contributors} />
         <LessonCover>
           <img
@@ -46,9 +56,9 @@ function HTMLStructure() {
           />
         </LessonCover>
         <p className="text-2xl font-light">
-          Orice website, fie că este un site de prezentare sau un complex
-          editor video, conține aceeași structură de bază cu mai
-          multe elemente descriptive și nu numai.
+          Orice website, fie că este un site de prezentare sau un complex editor
+          video, conține aceeași structură de bază cu mai multe elemente
+          descriptive și nu numai.
         </p>
         <section>
           <LessonHeading as="h2" id="structura">
@@ -56,40 +66,26 @@ function HTMLStructure() {
           </LessonHeading>
           <ResponsiveFlex className="justify-content-between">
             <div>
-              <p className="mb-4"> Fiecare pagină web este alcătuită din următoarele elemente principale: </p>
+              <p className="mb-4">
+                {' '}
+                Fiecare pagină web este alcătuită din următoarele elemente
+                principale:{' '}
+              </p>
               <ol className="with--checkmark">
                 <li className="mb-4">
-                  <span className="formatted text-bold">
-                    {'<!DOCTYPE html>'}
-                  </span>
-                  {' '}
+                  <FormattedText as="strong">{'<!DOCTYPE html>'}</FormattedText>{' '}
                   îi specifică browserului că acest document este de tipul HTML
                 </li>
                 <li className="mb-4">
-                  <span className="formatted text-bold">
-                    {'<html>'}
-                  </span>
-                  {' '}
-                  este elementul părinte al fiecărei pagini
+                  <FormattedText as="strong">{'<html>'}</FormattedText> este
+                  elementul părinte al fiecărei pagini
                 </li>
                 <li className="mb-4">
-                  <span className="formatted text-bold">
-                    {'<head>'}
-                  </span>
-                  {' '}
-                  și
-                  {' '}
-                  <span className="formatted text-bold">
-                    {'<body>'}
-                  </span>
-                  {' '}
-                  sunt descendenți ai elementului
-                  {' '}
-                  <span className="formatted text-bold">
-                    {'<html>'}
-                  </span>
-                  {' '}
-                  și vor fi definiți o singură dată
+                  <FormattedText as="strong">{'<head>'}</FormattedText> și{' '}
+                  <FormattedText as="strong">{'<body>'}</FormattedText> sunt
+                  descendenți ai elementului{' '}
+                  <FormattedText as="strong">{'<html>'}</FormattedText> și vor
+                  fi definiți o singură dată
                 </li>
               </ol>
             </div>
@@ -118,24 +114,13 @@ function HTMLStructure() {
             {'Elementul <head>'}
           </LessonHeading>
           <p>
-            În
-            {' '}
-            <span className="formatted text-bold">
-              {'<head>'}
-            </span>
-            {' '}
-            vom introduce elemente ce ne descriu website-ul, precum:
+            În <FormattedText as="strong">{'<head>'}</FormattedText> vom
+            introduce elemente ce ne descriu website-ul, precum:
           </p>
           <ul className="with--bullets">
-            <li>
-              titlul paginii
-            </li>
-            <li>
-              autorul
-            </li>
-            <li>
-              descrierea
-            </li>
+            <li>titlul paginii</li>
+            <li>autorul</li>
+            <li>descrierea</li>
           </ul>
           <Highlight
             className="my-5"
@@ -155,12 +140,10 @@ function HTMLStructure() {
             `}
           />
           <p>
-            <strong>Titlul va apărea în tabul browserului</strong>
-            ,
-            iar împreuna cu descrierea le vom vedea și în
-            <strong>motoarele de căutare</strong>
-            .
-            Spre exemplu, uite cum arată site-ul nostru în urma unei căutări pe Google:
+            <strong>Titlul va apărea în tabul browserului</strong>, iar împreuna
+            cu descrierea le vom vedea și în
+            <strong>motoarele de căutare</strong>. Spre exemplu, uite cum arată
+            site-ul nostru în urma unei căutări pe Google:
           </p>
           <LessonFigure
             withBorder
@@ -168,15 +151,11 @@ function HTMLStructure() {
             src={`${process.env.CLOUDFRONT_PUBLIC}/public/images/lessons/html-structure/frontend-ro-google-search.png`}
           />
           <p>
-            Mai mult, via taguri
-            {' '}
-            <span className="formatted text-bold">
-              {'<meta>'}
-            </span>
-            {' '}
-            putem controla cum apare site-ul când e distribuit pe rețele sociale precum Facebook,
-            LinkedIn etc. Adică noi ca și programatori alegem ce imagine, titlu și descriere
-            vor vedea utilizatorii acestor site-uri:
+            Mai mult, via taguri{' '}
+            <FormattedText as="strong">{'<meta>'}</FormattedText> putem controla
+            cum apare site-ul când e distribuit pe rețele sociale precum
+            Facebook, LinkedIn etc. Adică noi ca și programatori alegem ce
+            imagine, titlu și descriere vor vedea utilizatorii acestor site-uri:
           </p>
           <SideBySidePictures
             img1={{
@@ -189,11 +168,8 @@ function HTMLStructure() {
             }}
           />
           <p>
-            Ca să obținem rezultatul de mai sus, am folosit următoarele taguri în
-            {' '}
-            <span className="formatted text-bold">
-              {'<head>'}
-            </span>
+            Ca să obținem rezultatul de mai sus, am folosit următoarele taguri
+            în <FormattedText as="strong">{'<head>'}</FormattedText>
           </p>
           <Highlight
             className="my-5"
@@ -217,33 +193,16 @@ function HTMLStructure() {
 <meta property="og:image:height" content="630" />`}
           />
           <LessonTip>
-            Valorile pentru
-            {' '}
-            <span className="formatted text-bold">
-              property=""
-            </span>
-            {' '}
-            și
-            {' '}
-            <span className="formatted text-bold">
-              content=""
-            </span>
-            {' '}
-            din codul de mai sus sunt specifice standardului
-            {' '}
-            <a href="https://ogp.me/">
-              Open Graph
-            </a>
-            .
+            Valorile pentru{' '}
+            <FormattedText as="strong">property=""</FormattedText> și{' '}
+            <FormattedText as="strong">content=""</FormattedText> din codul de
+            mai sus sunt specifice standardului{' '}
+            <a href="https://ogp.me/">Open Graph</a>.
           </LessonTip>
           <p className="my-5">
-            Dar asta nu e tot. În
-            {' '}
-            <span className="formatted text-bold">
-              {'<head>'}
-            </span>
-            {' '}
-            vom adăuga și linkuri spre alte resurse folosite de site-ul nostru. De exemplu:
+            Dar asta nu e tot. În{' '}
+            <FormattedText as="strong">{'<head>'}</FormattedText> vom adăuga și
+            linkuri spre alte resurse folosite de site-ul nostru. De exemplu:
             foi de stiluri CSS, fișiere JavaScript etc.
           </p>
           <Highlight
@@ -256,15 +215,10 @@ function HTMLStructure() {
 `}
           />
           <LessonTip>
-            Nu uita că poți să vezi codul oricărui website prin
-            {' '}
-            <span className="formatted">
-              Click Dreapta
-              {' '}
-              {'->'}
-              {' '}
-              View Page Source
-            </span>
+            Nu uita că poți să vezi codul oricărui website prin{' '}
+            <FormattedText as="strong">
+              Click Dreapta {'->'} View Page Source
+            </FormattedText>
           </LessonTip>
         </section>
         <section className="my-5">
@@ -272,17 +226,19 @@ function HTMLStructure() {
             {'Elementul <body>'}
           </LessonHeading>
           <p>
-            De la sine prin denumirea lui, elementul body (trupul) este responsabil
-            pentru
-            {' '}
-            <strong>conținutul care-l vedem și cu care interacționăm efectiv în website</strong>
+            De la sine prin denumirea lui, elementul body (trupul) este
+            responsabil pentru{' '}
+            <strong>
+              conținutul care-l vedem și cu care interacționăm efectiv în
+              website
+            </strong>
             .
           </p>
           <p>
-            Aici vom adăuga toate elementele de care are nevoie pagina noastră: texte,
-            butoane, imagini, video-uri, liste, tabele, șamd.
-            Practic, aproape toate elementele HTML pot fi adăugate aici,
-            cu câteva excepții.
+            Aici vom adăuga toate elementele de care are nevoie pagina noastră:
+            texte, butoane, imagini, video-uri, liste, tabele, șamd. Practic,
+            aproape toate elementele HTML pot fi adăugate aici, cu câteva
+            excepții.
           </p>
           <Highlight
             language="html"
@@ -319,51 +275,41 @@ function HTMLStructure() {
             Rezumat
           </LessonHeading>
           <p>
-            În
-            {' '}
-            <span className="formatted text-bold">
-              {'<head>'}
-            </span>
-            {' '}
-            adăugam două tipuri de elemente:
+            În <FormattedText as="strong">{'<head>'}</FormattedText> adăugam
+            două tipuri de elemente:
           </p>
           <ul className="with--bullets">
             <li>
-              <strong>
-                Elemente descriptive
-              </strong>
-              , care ne dau informații despre site/aplicație
-              și sunt utile pentru SEO (search engine optimiation), inclusiv rețelele sociale
+              <strong>Elemente descriptive</strong>, care ne dau informații
+              despre site/aplicație și sunt utile pentru SEO (search engine
+              optimiation), inclusiv rețelele sociale
             </li>
             <li>
-              <strong>
-                Linkuri către resurse folosite de site-ul nostru
-              </strong>
-              precum: foi de stiluri
-              CSS, fisiere JavaScript, imagini și fonturi pentu a îmbunătăți performanța, etc.
+              <strong>Linkuri către resurse folosite de site-ul nostru</strong>
+              precum: foi de stiluri CSS, fisiere JavaScript, imagini și fonturi
+              pentu a îmbunătăți performanța, etc.
             </li>
           </ul>
           <p>
-            În
-            {' '}
-            <span className="formatted text-bold">
-              {'<body>'}
-            </span>
-            {' '}
-            adăugăm elementele ce fac parte efectiv din site-ul nostru,
-            și cu care vor interacționa utilizatorii. Aproape toate elementele
-            HTML (cu câteva excepții) vor fi adăugate aici.
+            În <FormattedText as="strong">{'<body>'}</FormattedText> adăugăm
+            elementele ce fac parte efectiv din site-ul nostru, și cu care vor
+            interacționa utilizatorii. Aproape toate elementele HTML (cu câteva
+            excepții) vor fi adăugate aici.
           </p>
         </section>
         <LessonResources
           className="my-5"
-          links={[{
-            text: 'What\'s in head?',
-            url: 'https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML',
-          }, {
-            text: 'View Source',
-            url: 'https://developer.mozilla.org/en-US/docs/Tools/View_source',
-          }]}
+          links={[
+            {
+              text: "What's in head?",
+              url:
+                'https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML',
+            },
+            {
+              text: 'View Source',
+              url: 'https://developer.mozilla.org/en-US/docs/Tools/View_source',
+            },
+          ]}
         />
       </Lesson>
     </>
@@ -372,15 +318,18 @@ function HTMLStructure() {
 
 type ResponsiveFlexProps = PropsWithChildren<HTMLAttributes<HTMLDivElement>>;
 
-const ResponsiveFlex = React.forwardRef<
-  HTMLDivElement,
-  ResponsiveFlexProps
->(({ children, ...rest }: ResponsiveFlexProps, ref) => {
-  return (
-    <div {...rest} ref={ref} className={`${styles['responsive-flex']} ${rest.className ?? ''}`}>
-      {children}
-    </div>
-  );
-});
+const ResponsiveFlex = React.forwardRef<HTMLDivElement, ResponsiveFlexProps>(
+  ({ children, ...rest }: ResponsiveFlexProps, ref) => {
+    return (
+      <div
+        {...rest}
+        ref={ref}
+        className={`${styles['responsive-flex']} ${rest.className ?? ''}`}
+      >
+        {children}
+      </div>
+    );
+  }
+);
 
 export default HTMLStructure;

--- a/client/curriculum/html/Images.tsx
+++ b/client/curriculum/html/Images.tsx
@@ -15,6 +15,7 @@ import Lesson, {
 import { Pava } from '~/services/contributors';
 import Highlight from '~/components/Highlight/Highlight';
 import SideBySidePictures from '~/components/SideBySidePictures';
+import FormattedText from '~/components/FormattedText';
 
 const contributors = [Pava];
 const chapters = [
@@ -24,13 +25,16 @@ const chapters = [
   {
     title: 'Imagini responsive',
     id: 'imagini-responsive',
-    subchapters: [{
-      title: 'Atributul srcset',
-      id: 'srcset',
-    }, {
-      title: 'Proprietatea image-set',
-      id: 'image-set',
-    }],
+    subchapters: [
+      {
+        title: 'Atributul srcset',
+        id: 'srcset',
+      },
+      {
+        title: 'Proprietatea image-set',
+        id: 'image-set',
+      },
+    ],
   },
   { title: 'Elementul <picture>', id: 'elementul-picture' },
   { title: 'Exerciții', id: 'exercitii' },
@@ -76,30 +80,26 @@ export default function ImagesLesson() {
           />
         </LessonCover>
         <p className="text-2xl font-light">
-          Cred că putem cu toții admite că un Internet fără imagini ar
-          fi destul de plictisitor. Deci hai să
-          încheiem așteptarea și să vedem cum adăugăm imagini
-          în site-urile noastre și care sunt cele mai bune practici legate de acest subiect.
+          Cred că putem cu toții admite că un Internet fără imagini ar fi destul
+          de plictisitor. Deci hai să încheiem așteptarea și să vedem cum
+          adăugăm imagini în site-urile noastre și care sunt cele mai bune
+          practici legate de acest subiect.
         </p>
         <section>
           <LessonHeading as="h2" id="elementul-img">
             {'Elementul <img>'}
           </LessonHeading>
           <p>
-            Primul și cel mai comun mod de a adăuga o imagine este folosind elementul
-            {' '}
-            <strong>img</strong>
-            {' '}
-            alături de 2 atribute:
+            Primul și cel mai comun mod de a adăuga o imagine este folosind
+            elementul <strong>img</strong> alături de 2 atribute:
           </p>
           <ul className="with--bullets">
             <li>
-              <strong>src</strong>
-              : pentru a specifica URL-ul imaginii
+              <strong>src</strong>: pentru a specifica URL-ul imaginii
             </li>
             <li>
-              <strong>alt</strong>
-              : pentru a descrie conținutul imaginii - în caz că aceasta nu poate fi încărcată
+              <strong>alt</strong>: pentru a descrie conținutul imaginii - în
+              caz că aceasta nu poate fi încărcată
             </li>
           </ul>
           <Highlight
@@ -112,30 +112,29 @@ export default function ImagesLesson() {
 />`}
           />
           <p>
-            Dacă imaginea se află la acel URL și avem conexiune la internet
-            vom obține o pagină ca în imaginea din stânga. Însă, dacă
-            browserul nu a putut încărca imaginea, vom vedea descrierea
-            text ca în exemplul din dreapta.
+            Dacă imaginea se află la acel URL și avem conexiune la internet vom
+            obține o pagină ca în imaginea din stânga. Însă, dacă browserul nu a
+            putut încărca imaginea, vom vedea descrierea text ca în exemplul din
+            dreapta.
           </p>
           <SideBySidePictures
             img1={{
-              src: 'https://d3tycb976jpudc.cloudfront.net/demo-assets/golden-retriever-and-ball.jpg',
+              src:
+                'https://d3tycb976jpudc.cloudfront.net/demo-assets/golden-retriever-and-ball.jpg',
               alt: 'Imagine încărcată cu succes într-o pagină Web',
               demo: '/demo/html/imagine-incarcata-cu-succes',
             }}
             img2={{
               src: '/images/lessons/images/image-alt.png',
-              alt: 'Descrierea text a imaginii, dacă aceasta nu a putut fi încărcată',
+              alt:
+                'Descrierea text a imaginii, dacă aceasta nu a putut fi încărcată',
               demo: '/demo/html/text-alternativ-imagine',
             }}
           />
           <p>
-            Este foarte important să nu uităm de atributul
-            {' '}
-            <strong>alt</strong>
-            .
-            Pe lângă cazul menționat mai sus, acesta ajută și persoanele cu dizabilități
-            ce consumă conținut Web via screen readere.
+            Este foarte important să nu uităm de atributul <strong>alt</strong>.
+            Pe lângă cazul menționat mai sus, acesta ajută și persoanele cu
+            dizabilități ce consumă conținut Web via screen readere.
             {/* Uite un demo folosind progamul XXX? */}
           </p>
 
@@ -143,16 +142,10 @@ export default function ImagesLesson() {
           {/* <AudioPlayer className="my-5" src="" title="Web captions demo" /> */}
 
           <LessonTip>
-            De aceea, o pagină ce conține imagini
-            {' '}
-            <strong>fără atributul alt</strong>
-            {' '}
-            nu este
-            {' '}
+            De aceea, o pagină ce conține imagini{' '}
+            <strong>fără atributul alt</strong> nu este{' '}
             <Link href="/html/validarea-paginilor-html">
-              <a>
-                considerată validă
-              </a>
+              <a>considerată validă</a>
             </Link>
             .
           </LessonTip>
@@ -162,13 +155,13 @@ export default function ImagesLesson() {
             Width & Height
           </LessonHeading>
           <p>
-            De multe ori imaginile de pe site-uri își vor adapta dimensiunea în funcție de
-            ecranul dispozitivului folosit: mai mici pe telefoane și tablete, mai mari
-            pe laptop-uri și desktop-uri.
+            De multe ori imaginile de pe site-uri își vor adapta dimensiunea în
+            funcție de ecranul dispozitivului folosit: mai mici pe telefoane și
+            tablete, mai mari pe laptop-uri și desktop-uri.
           </p>
           <p>
-            În galeria de mai jos avem 2 imagini pe fiecare rând, fiecare ocupând
-            exact 45% din lățimea ecranului - indiferent care e aceasta.
+            În galeria de mai jos avem 2 imagini pe fiecare rând, fiecare
+            ocupând exact 45% din lățimea ecranului - indiferent care e aceasta.
           </p>
           <LessonFigure
             withBorder
@@ -177,13 +170,10 @@ export default function ImagesLesson() {
             demo="/demo/html/galerie-imagini-fixa"
           />
           <p>
-            Însă există situații în care o imagine va avea aceleași dimensiuni fixe indiferent
-            de dispozitiv. Un exemplu ar putea fi logo-ul unei companii
-            aflat de obicei în
-            {' '}
-            <strong className="formatted">{'<header>'}</strong>
-            {' '}
-            -ul paginii.
+            Însă există situații în care o imagine va avea aceleași dimensiuni
+            fixe indiferent de dispozitiv. Un exemplu ar putea fi logo-ul unei
+            companii aflat de obicei în{' '}
+            <FormattedText as="strong">{'<header>'}</FormattedText> -ul paginii.
           </p>
           <LessonFigure
             withBorder
@@ -192,17 +182,11 @@ export default function ImagesLesson() {
             demo="/demo/html/imagine-cu-dimensiuni-fixe"
           />
           <p>
-            În astfel de cazuri, în care
-            {' '}
-            <strong>știm dinainte dimensiunea</strong>
-            {' '}
-            , este recomandat
-            să adăugam și atributele
+            În astfel de cazuri, în care{' '}
+            <strong>știm dinainte dimensiunea</strong> , este recomandat să
+            adăugam și atributele
             <strong> width </strong>
-            și
-            {' '}
-            <strong> height </strong>
-            .
+            și <strong> height </strong>.
           </p>
           <Highlight
             className="my-5"
@@ -216,13 +200,11 @@ export default function ImagesLesson() {
 />`}
           />
           <p>
-            Astfel, browser-ul va ști dimensiunile imaginii înainte de a o descărca
-            iar experiența utilizatorilor va fi extrem de fluidă. Astfel evităm
-            situația de mai jos unde textul se re-aranjează după încărcarea imaginii
-            - problemă cunoscută sub numele de
-            {' '}
-            <strong>content/layout shifting</strong>
-            .
+            Astfel, browser-ul va ști dimensiunile imaginii înainte de a o
+            descărca iar experiența utilizatorilor va fi extrem de fluidă.
+            Astfel evităm situația de mai jos unde textul se re-aranjează după
+            încărcarea imaginii - problemă cunoscută sub numele de{' '}
+            <strong>content/layout shifting</strong>.
           </p>
           <LessonFigure
             isVideo
@@ -236,16 +218,19 @@ export default function ImagesLesson() {
         <section>
           <p>
             Ce am arătat până acum reprezintă fundamentele imaginilor în HTML.
-            Sunt lucrurile pe care le vei folosi în marea majoritate a cazurilor...
+            Sunt lucrurile pe care le vei folosi în marea majoritate a
+            cazurilor...
           </p>
 
           <p>
-            Mai jos continuăm să discutăm despre diverse tehnici
-            pentru a optimiza servirea imaginilor și a oferi cea mai
-            bună experiență posibilă, care la randul ei va mări
-            șansele ca
-            {' '}
-            <a href="https://web.dev/site-speed-and-business-metrics/" target="_blank" rel="noreferrer">
+            Mai jos continuăm să discutăm despre diverse tehnici pentru a
+            optimiza servirea imaginilor și a oferi cea mai bună experiență
+            posibilă, care la randul ei va mări șansele ca{' '}
+            <a
+              href="https://web.dev/site-speed-and-business-metrics/"
+              target="_blank"
+              rel="noreferrer"
+            >
               proiectul/business-ul nostru să aibă succes.
             </a>
             .
@@ -256,45 +241,35 @@ export default function ImagesLesson() {
             Lazy loading
           </LessonHeading>
           <blockquote>
-            Most of the images on the web are downloaded,
-            decoded and rendered only never to be seen, as [...]
-            the user never scrolled that far.
-            -
-            {' '}
+            Most of the images on the web are downloaded, decoded and rendered
+            only never to be seen, as [...] the user never scrolled that far. -{' '}
             <small>
-              <a href="https://twitter.com/yoavweiss" target="_blank" rel="noopener noreferrer">Yoav Weiss</a>
+              <a
+                href="https://twitter.com/yoavweiss"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Yoav Weiss
+              </a>
             </small>
           </blockquote>
           <p>
-            Citatul de mai sus a rămas - din păcate - la fel de adevărat...
-            De câte ori nu ai deschis o pagină Web și apoi ai ieșit de acolo fără
-            a citi mai mult de primul paragraf?
+            Citatul de mai sus a rămas - din păcate - la fel de adevărat... De
+            câte ori nu ai deschis o pagină Web și apoi ai ieșit de acolo fără a
+            citi mai mult de primul paragraf?
           </p>
           <p>
-            În background însă, browser-ul a încărcat toate imaginile,
-            ceea ce e o risipă pentru că noi nu le-am văzut pe toate.
-            Ideal ar fi să încărcăm imaginile
-            <strong>
-              {' '}
-              doar atunci când avem nevoie de ele
-              {' '}
-            </strong>
-            .
-            {/* , */}
+            În background însă, browser-ul a încărcat toate imaginile, ceea ce e
+            o risipă pentru că noi nu le-am văzut pe toate. Ideal ar fi să
+            încărcăm imaginile
+            <strong> doar atunci când avem nevoie de ele </strong>.{/* , */}
             {/* cum se întâmplă în video-ul din dreapta. */}
           </p>
           {/* TODO: video demo */}
           {/* <h1> VIDEO DEMO </h1> */}
           <p>
-            Pentru a rezolva această problemă vom
-            folosi atributul
-            {' '}
-            <strong>loading</strong>
-            {' '}
-            și valoarea
-            {' '}
-            <strong>lazy</strong>
-            .
+            Pentru a rezolva această problemă vom folosi atributul{' '}
+            <strong>loading</strong> și valoarea <strong>lazy</strong>.
           </p>
           <Highlight
             className="my-5"
@@ -309,15 +284,11 @@ export default function ImagesLesson() {
           />
           <p>
             Acum browserul va descărca imaginea doar când ne
-            <em>"apropiem"</em>
-            {' '}
-            de ea. Fiecare browser are propriile metrici legate
-            de ce înseamnă această apropiere, însă nu trebuie să ne batem
-            capul cu asta. Regula generală e să adăugăm atributul
-            {' '}
-            <strong className="formatted">loading="lazy"</strong>
-            {' '}
-            dacă avem multe imagini în pagină.
+            <em>"apropiem"</em> de ea. Fiecare browser are propriile metrici
+            legate de ce înseamnă această apropiere, însă nu trebuie să ne batem
+            capul cu asta. Regula generală e să adăugăm atributul{' '}
+            <FormattedText as="strong">loading="lazy"</FormattedText> dacă avem
+            multe imagini în pagină.
           </p>
         </section>
         <section>
@@ -326,17 +297,16 @@ export default function ImagesLesson() {
           </LessonHeading>
           <p>
             Am pornit de la imagini simple, am optimizat experiența folosind
-            atributele width/height iar apoi am reușit să incărcăm doar imaginile
-            de care avem nevoie folosind atributul
-            {' '}
-            <strong className="formatted">
-              loading
-            </strong>
-            . Acum e momentul să mergem un pas mai departe în călătoria spre performanță
-            și să încărcăm imaginea cea mai potrivită din punct de vedere al rezoluției.
+            atributele width/height iar apoi am reușit să incărcăm doar
+            imaginile de care avem nevoie folosind atributul{' '}
+            <FormattedText as="strong">loading</FormattedText>. Acum e momentul
+            să mergem un pas mai departe în călătoria spre performanță și să
+            încărcăm imaginea cea mai potrivită din punct de vedere al
+            rezoluției.
           </p>
           <p>
-            De exemplu, să presupunem că avem o imagine care va acoperi întreaga pagină:
+            De exemplu, să presupunem că avem o imagine care va acoperi întreaga
+            pagină:
           </p>
           <LessonFigure
             withBorder
@@ -344,21 +314,22 @@ export default function ImagesLesson() {
             alt="Imagine full-screen intr-o pagină Web"
           />
           <blockquote>
-            La ce rezoluție salvăm imaginea pentru a fi 100% clară pe toate dispozitivele?
+            La ce rezoluție salvăm imaginea pentru a fi 100% clară pe toate
+            dispozitivele?
           </blockquote>
           <p>
-            Știind că site-ul poate fi văzut atât de pe dispozitive mobile,
-            cu ecrane mai mici, cât și de pe desktop-uri sau chiar televizoare,
-            o primă soluție ar fi să salvăm imaginea la o rezoluție cât mai
-            înaltă - să zicem 4K- pentru a ne asigura că totul e ok.
+            Știind că site-ul poate fi văzut atât de pe dispozitive mobile, cu
+            ecrane mai mici, cât și de pe desktop-uri sau chiar televizoare, o
+            primă soluție ar fi să salvăm imaginea la o rezoluție cât mai înaltă
+            - să zicem 4K- pentru a ne asigura că totul e ok.
             {/* Pentru imaginea folosita ca demo in acest capitol inseamna o dimensiune de xMB. */}
           </p>
           <p>
             Deși soluția ar funcționa, ea nu e deloc eficientă, căci vom încărca
-            mereu aceeași imagine de rezoluție înaltă și mulți MBs.
-            Pe telefon de exemplu, unde ecranul e mai mic, nu avem nevoie
-            de toți cei 8+ milioane de pixeli (3840 x 2160).
-            Dacă luăm în calcul și conexiunea la internet, experiența poate arăta așa:
+            mereu aceeași imagine de rezoluție înaltă și mulți MBs. Pe telefon
+            de exemplu, unde ecranul e mai mic, nu avem nevoie de toți cei 8+
+            milioane de pixeli (3840 x 2160). Dacă luăm în calcul și conexiunea
+            la internet, experiența poate arăta așa:
           </p>
           <LessonFigure
             isVideo
@@ -369,18 +340,17 @@ export default function ImagesLesson() {
           />
           <p>
             Ideal ar fi ca pe telefon să încărcăm exact aceeași imagine dar la o
-            rezoluție mai mică, pe tabletă la o rezoluție mijlocie și la o rezoluție
-            cât mai inaltă pe ecrane mari: desktop and beyond.
+            rezoluție mai mică, pe tabletă la o rezoluție mijlocie și la o
+            rezoluție cât mai inaltă pe ecrane mari: desktop and beyond.
           </p>
           <section>
             <LessonHeading as="h3" id="srcset">
               Atributul srcset
             </LessonHeading>
             <p>
-              Din fericire putem rezolva această problemă folosindu-ne de atributul
-              {' '}
-              <strong>srcset</strong>
-              . Hai să luăm imaginea noastră și să facem resize la 3 rezoluții diferite:
+              Din fericire putem rezolva această problemă folosindu-ne de
+              atributul <strong>srcset</strong>. Hai să luăm imaginea noastră și
+              să facem resize la 3 rezoluții diferite:
             </p>
             <LessonFigure
               withBorder
@@ -388,25 +358,23 @@ export default function ImagesLesson() {
               alt="Aceeași imagine în 3 dimensiuni diferite"
             />
             <LessonTip>
-              Pe Windows putem face resize cu
-              {' '}
-              <strong>Paint</strong>
-              {' '}
-              iar pe MacOS folosind
-              {' '}
+              Pe Windows putem face resize cu <strong>Paint</strong> iar pe
+              MacOS folosind{' '}
               <strong>
-                <a href="https://support.apple.com/guide/preview/resize-rotate-or-flip-an-image-prvw2015/mac" target="_blank" rel="noreferrer">Preview App</a>
-              </strong>
-              {' '}
+                <a
+                  href="https://support.apple.com/guide/preview/resize-rotate-or-flip-an-image-prvw2015/mac"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Preview App
+                </a>
+              </strong>{' '}
               .
             </LessonTip>
             <p>
-              Apoi vom adăuga atributul
-              {' '}
-              <strong>srcset</strong>
-              {' '}
-              unde definim diferitele
-              surse ale imaginii împreună cu dimensiunea (în lățime) a fiecăreia:
+              Apoi vom adăuga atributul <strong>srcset</strong> unde definim
+              diferitele surse ale imaginii împreună cu dimensiunea (în lățime)
+              a fiecăreia:
             </p>
             <Highlight
               className="my-5"
@@ -436,16 +404,10 @@ export default function ImagesLesson() {
             Astfel ne asiguram ca imaginile nu vor iesi din pagina.
           </LessonTip> */}
             <p>
-              Șiiii voilà. Dacă mergem în
-              {' '}
-              <a href="/intro/devtools">modul responsive</a>
-              {' '}
-              - și ținem tabul
-              {' '}
-              <strong>network</strong>
-              {' '}
-              deschis vom observa cum diferite surse ale imaginii
-              se încarcă la rezoluții diferite.
+              Șiiii voilà. Dacă mergem în{' '}
+              <a href="/intro/devtools">modul responsive</a> - și ținem tabul{' '}
+              <strong>network</strong> deschis vom observa cum diferite surse
+              ale imaginii se încarcă la rezoluții diferite.
             </p>
             <LessonFigure
               isVideo
@@ -455,19 +417,12 @@ export default function ImagesLesson() {
               alt="Diferite surse ale imaginii se încarcă la rezoluții diferite"
             />
             <p>
-              Te încurajăm să experimentezi și cu opțiunea
-              {' '}
+              Te încurajăm să experimentezi și cu opțiunea{' '}
               <Link href="intro/devtools">
-                <a target="_blank">
-                  DRP (Device Pixel Ratio)
-                </a>
-              </Link>
-              {' '}
-              De exemplu, cu o valoare
-              de 2 și o lățime de 650px se va incărca imaginea
-              {' '}
-              <strong>red_bycicle__med.jpg</strong>
-              .
+                <a target="_blank">DRP (Device Pixel Ratio)</a>
+              </Link>{' '}
+              De exemplu, cu o valoare de 2 și o lățime de 650px se va incărca
+              imaginea <strong>red_bycicle__med.jpg</strong>.
             </p>
           </section>
           <section>
@@ -475,20 +430,14 @@ export default function ImagesLesson() {
               Proprietatea image-set
             </LessonHeading>
             <p>
-              Până de curând singurul mod de a face imaginile din CSS (cele puse prin
-              {' '}
-              <strong className="formatted">background-image:</strong>
-              {' '}
-              )
-              responsive a fost să punem mai multe reguli
-              {' '}
-              <strong className="formatted">@media-query</strong>
-              {' '}
-              și să specificăm pentru fiecare o altă imagine.
+              Până de curând singurul mod de a face imaginile din CSS (cele puse
+              prin <FormattedText as="strong">background-image:</FormattedText>{' '}
+              ) responsive a fost să punem mai multe reguli{' '}
+              <FormattedText as="strong">@media-query</FormattedText> și să
+              specificăm pentru fiecare o altă imagine.
             </p>
             <p>
-              Dar odată cu introducerea proprietății
-              {' '}
+              Dar odată cu introducerea proprietății{' '}
               <a
                 target="_blank"
                 className="text-bold"
@@ -496,9 +445,9 @@ export default function ImagesLesson() {
                 rel="noreferrer"
               >
                 image-set()
-              </a>
-              {' '}
-              putem lăsa browserul să aleagă cea mai bună imagine în funcție de rezoluția ecranului:
+              </a>{' '}
+              putem lăsa browserul să aleagă cea mai bună imagine în funcție de
+              rezoluția ecranului:
             </p>
             <Highlight
               language="css"
@@ -522,11 +471,9 @@ export default function ImagesLesson() {
             />
             <LessonTip icon={faQuestion}>
               Această proprietate nu are încă suport nativ în toate Browserele,
-              așa că în exemplul de mai sus am prefixat regulat cu
-              {' '}
-              <span className="formatted">-webkit</span>
-              {' '}
-              pentru a funcționa și în Chrome sau Safari.
+              așa că în exemplul de mai sus am prefixat regulat cu{' '}
+              <FormattedText as="span">-webkit</FormattedText> pentru a
+              funcționa și în Chrome sau Safari.
             </LessonTip>
           </section>
         </section>
@@ -535,88 +482,65 @@ export default function ImagesLesson() {
             {'Elementul <picture>'}
           </LessonHeading>
           <p>
-            După cum ai văzut până acum, elementul
-            {' '}
-            <strong className="formatted">{'<img>'}</strong>
-            {' '}
-            - deși destul de simplu în utilizare - ne oferă mai multe funcționalități
-            care ne permit să optimizăm imaginile și experiența utilizatorilor.
-            Cu toate acestea, a mai rămas totuși o ultimă optimizare,
-            și anume folosirea unor formate moderne pentru imagini.
+            După cum ai văzut până acum, elementul{' '}
+            <FormattedText as="strong">{'<img>'}</FormattedText> - deși destul
+            de simplu în utilizare - ne oferă mai multe funcționalități care ne
+            permit să optimizăm imaginile și experiența utilizatorilor. Cu toate
+            acestea, a mai rămas totuși o ultimă optimizare, și anume folosirea
+            unor formate moderne pentru imagini.
           </p>
           <blockquote>
-            De ce am vrea alte formate? Nu sunt
-            {' '}
-            <strong>JPG</strong>
-            {' '}
-            sau
-            {' '}
-            <strong>PNG</strong>
-            {' '}
-            de ajuns?
+            De ce am vrea alte formate? Nu sunt <strong>JPG</strong> sau{' '}
+            <strong>PNG</strong> de ajuns?
           </blockquote>
           <p>
-            Hmmm.... nu chiar. Există formate mai moderne precum
-            {' '}
-            <strong>WebP</strong>
-            {' '}
-            sau
-            {' '}
-            <strong>AVIF</strong>
-            {' '}
-            care
-            oferă aceeași calitate a imaginii la o dimensiune mai mică.
-            Uite diferențele de dimensiune ale acestei imagini în funcție de format:
+            Hmmm.... nu chiar. Există formate mai moderne precum{' '}
+            <strong>WebP</strong> sau <strong>AVIF</strong> care oferă aceeași
+            calitate a imaginii la o dimensiune mai mică. Uite diferențele de
+            dimensiune ale acestei imagini în funcție de format:
           </p>
           <LessonTable {...sizesTable} className="my-5" />
           <p>
-            După cum vezi formatele WebP și AVIF sunt mai mici decât JPG sau PNG,
-            deci imaginile în acest format se vor incărca mai repede decât celelalte.
-            Problema este că nu toate browserele înțeleg aceste noi formate.
+            După cum vezi formatele WebP și AVIF sunt mai mici decât JPG sau
+            PNG, deci imaginile în acest format se vor incărca mai repede decât
+            celelalte. Problema este că nu toate browserele înțeleg aceste noi
+            formate.
           </p>
           <p>
-            După cum vedem pe
-            {' '}
-            <a href="https://CanIUse.com" target="_blank" rel="noreferrer">Can I use...</a>
-            - AVIF are suport doar în ultimele versiuni
-            de Google Chrome în timp ce WebP este mai comun însă tot lipsește din
-            IOS 13 sau Internet Explorer 11.
+            După cum vedem pe{' '}
+            <a href="https://CanIUse.com" target="_blank" rel="noreferrer">
+              Can I use...
+            </a>
+            - AVIF are suport doar în ultimele versiuni de Google Chrome în timp
+            ce WebP este mai comun însă tot lipsește din IOS 13 sau Internet
+            Explorer 11.
           </p>
           <SideBySidePictures
             direction="column"
             img1={{
-              src: 'https://d3tycb976jpudc.cloudfront.net/demo-assets/caniuse-webp.png',
+              src:
+                'https://d3tycb976jpudc.cloudfront.net/demo-assets/caniuse-webp.png',
               alt: 'Suportul browserelor pentru formatul WebP',
               demo: 'https://caniuse.com/?search=webp',
             }}
             img2={{
-              src: 'https://d3tycb976jpudc.cloudfront.net/demo-assets/caniuse-avif.png',
+              src:
+                'https://d3tycb976jpudc.cloudfront.net/demo-assets/caniuse-avif.png',
               alt: 'Suportul browserelor pentru formatul Avif',
               demo: 'https://caniuse.com/?search=avif',
             }}
           />
           <p>
-            Deci avem nevoie de o modalitate prin care browsere care înțeleg
-            {' '}
-            <strong>WebP</strong>
-            {' '}
-            sau
-            {' '}
-            <strong> Avif</strong>
-            {' '}
-            să descarce aceste formate, în timp ce celelalte să rămână la JPG.
-            Această tehnică se numește general
-            {' '}
-            <a href="/concepte/graceful-degradation">graceful degradation</a>
-            .
+            Deci avem nevoie de o modalitate prin care browsere care înțeleg{' '}
+            <strong>WebP</strong> sau <strong> Avif</strong> să descarce aceste
+            formate, în timp ce celelalte să rămână la JPG. Această tehnică se
+            numește general{' '}
+            <a href="/concepte/graceful-degradation">graceful degradation</a>.
           </p>
           <p>
-            Thankfully, această soluție ne este permisă de tag-ul
-            {' '}
-            <strong className="formatted">{'<picture>'}</strong>
-            {' '}
-            ,
-            unde putem specifica mai multe surse pentru o imagine și să lăsăm
+            Thankfully, această soluție ne este permisă de tag-ul{' '}
+            <FormattedText as="strong">{'<picture>'}</FormattedText> , unde
+            putem specifica mai multe surse pentru o imagine și să lăsăm
             browserul să o aleagă pe cea pe care o înțelege.
           </p>
           <Highlight
@@ -657,55 +581,46 @@ export default function ImagesLesson() {
           />
         </section>
         <p>
-          Ordinea elementelor
-          {' '}
-          <strong className="formatted">{'<source>'}</strong>
-          {' '}
-          este extrem de importantă căci browserul le va parcurge
-          de sus-in-jos și o va alege pe prima compatibilă. De asemenea,
-          în fiecare dintre ele trebuie adăugat - via atributul
-          {' '}
-          <strong>srcset</strong>
-          {' '}
-          - mai multe surse de dimensiuni diferite.
-          Astfel browserul nu alege numai formatul cel mai bun, cât și
-          dimensiunea optimă a imaginii. Best of both worlds! 💪
+          Ordinea elementelor{' '}
+          <FormattedText as="strong">{'<source>'}</FormattedText> este extrem de
+          importantă căci browserul le va parcurge de sus-in-jos și o va alege
+          pe prima compatibilă. De asemenea, în fiecare dintre ele trebuie
+          adăugat - via atributul <strong>srcset</strong> - mai multe surse de
+          dimensiuni diferite. Astfel browserul nu alege numai formatul cel mai
+          bun, cât și dimensiunea optimă a imaginii. Best of both worlds! 💪
         </p>
         <p>
-          PS: poate ai observat acel ultim
-          {' '}
-          <strong className="formatted">{'<img>'}</strong>
-          {' '}
-          tag. Ei bine, avem nevoie de el pentru
-          a specifica descrierea imaginii - în caz că aceasta nu poate fi încărcată,
-          cât și pentru eventuala adaugare a unor atribute extra - cum ar fi
-          {' '}
-          <strong>loading</strong>
-          . Iar în cazurile mai rare în care utilizatorii folosesc browsere
-          destul de vechi, ce nu înțeleg elementul
-          {' '}
-          <strong className="formatted">{'<picture>'}</strong>
-          {' '}
-          , acestea vor înțelege
-          totuși tag-ul
-          {' '}
-          <strong className="formatted">{'<img>'}</strong>
-          {' '}
-          și îl vor arăta pe acesta.
+          PS: poate ai observat acel ultim{' '}
+          <FormattedText as="strong">{'<img>'}</FormattedText> tag. Ei bine,
+          avem nevoie de el pentru a specifica descrierea imaginii - în caz că
+          aceasta nu poate fi încărcată, cât și pentru eventuala adaugare a unor
+          atribute extra - cum ar fi <strong>loading</strong>. Iar în cazurile
+          mai rare în care utilizatorii folosesc browsere destul de vechi, ce nu
+          înțeleg elementul{' '}
+          <FormattedText as="strong">{'<picture>'}</FormattedText> , acestea vor
+          înțelege totuși tag-ul{' '}
+          <FormattedText as="strong">{'<img>'}</FormattedText> și îl vor arăta
+          pe acesta.
         </p>
         <div className="dots" />
         <LessonResources
           className="my-5"
-          links={[{
-            text: 'Documentația completă a elementului <img> pe MDN',
-            url: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img',
-          }, {
-            text: 'Documentația completă a elementului <picture> pe MDN',
-            url: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture',
-          }, {
-            text: 'Mai multe detalii despre imagini Responsive',
-            url: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture',
-          },
+          links={[
+            {
+              text: 'Documentația completă a elementului <img> pe MDN',
+              url:
+                'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img',
+            },
+            {
+              text: 'Documentația completă a elementului <picture> pe MDN',
+              url:
+                'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture',
+            },
+            {
+              text: 'Mai multe detalii despre imagini Responsive',
+              url:
+                'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture',
+            },
           ]}
         />
       </Lesson>

--- a/client/curriculum/html/Images.tsx
+++ b/client/curriculum/html/Images.tsx
@@ -91,14 +91,20 @@ export default function ImagesLesson() {
           </LessonHeading>
           <p>
             Primul și cel mai comun mod de a adăuga o imagine este folosind
-            elementul <strong>img</strong> alături de 2 atribute:
+            elementul
+            {' '}
+            <strong>img</strong>
+            {' '}
+            alături de 2 atribute:
           </p>
           <ul className="with--bullets">
             <li>
-              <strong>src</strong>: pentru a specifica URL-ul imaginii
+              <strong>src</strong>
+              : pentru a specifica URL-ul imaginii
             </li>
             <li>
-              <strong>alt</strong>: pentru a descrie conținutul imaginii - în
+              <strong>alt</strong>
+              : pentru a descrie conținutul imaginii - în
               caz că aceasta nu poate fi încărcată
             </li>
           </ul>
@@ -132,7 +138,10 @@ export default function ImagesLesson() {
             }}
           />
           <p>
-            Este foarte important să nu uităm de atributul <strong>alt</strong>.
+            Este foarte important să nu uităm de atributul
+            {' '}
+            <strong>alt</strong>
+            .
             Pe lângă cazul menționat mai sus, acesta ajută și persoanele cu
             dizabilități ce consumă conținut Web via screen readere.
             {/* Uite un demo folosind progamul XXX? */}
@@ -142,8 +151,12 @@ export default function ImagesLesson() {
           {/* <AudioPlayer className="my-5" src="" title="Web captions demo" /> */}
 
           <LessonTip>
-            De aceea, o pagină ce conține imagini{' '}
-            <strong>fără atributul alt</strong> nu este{' '}
+            De aceea, o pagină ce conține imagini
+            {' '}
+            <strong>fără atributul alt</strong>
+            {' '}
+            nu este
+            {' '}
             <Link href="/html/validarea-paginilor-html">
               <a>considerată validă</a>
             </Link>
@@ -172,8 +185,11 @@ export default function ImagesLesson() {
           <p>
             Însă există situații în care o imagine va avea aceleași dimensiuni
             fixe indiferent de dispozitiv. Un exemplu ar putea fi logo-ul unei
-            companii aflat de obicei în{' '}
-            <FormattedText as="strong">{'<header>'}</FormattedText> -ul paginii.
+            companii aflat de obicei în
+            {' '}
+            <FormattedText as="strong">{'<header>'}</FormattedText>
+            {' '}
+            -ul paginii.
           </p>
           <LessonFigure
             withBorder
@@ -182,11 +198,17 @@ export default function ImagesLesson() {
             demo="/demo/html/imagine-cu-dimensiuni-fixe"
           />
           <p>
-            În astfel de cazuri, în care{' '}
-            <strong>știm dinainte dimensiunea</strong> , este recomandat să
+            În astfel de cazuri, în care
+            {' '}
+            <strong>știm dinainte dimensiunea</strong>
+            {' '}
+            , este recomandat să
             adăugam și atributele
             <strong> width </strong>
-            și <strong> height </strong>.
+            și
+            {' '}
+            <strong> height </strong>
+            .
           </p>
           <Highlight
             className="my-5"
@@ -203,8 +225,10 @@ export default function ImagesLesson() {
             Astfel, browser-ul va ști dimensiunile imaginii înainte de a o
             descărca iar experiența utilizatorilor va fi extrem de fluidă.
             Astfel evităm situația de mai jos unde textul se re-aranjează după
-            încărcarea imaginii - problemă cunoscută sub numele de{' '}
-            <strong>content/layout shifting</strong>.
+            încărcarea imaginii - problemă cunoscută sub numele de
+            {' '}
+            <strong>content/layout shifting</strong>
+            .
           </p>
           <LessonFigure
             isVideo
@@ -225,7 +249,8 @@ export default function ImagesLesson() {
           <p>
             Mai jos continuăm să discutăm despre diverse tehnici pentru a
             optimiza servirea imaginilor și a oferi cea mai bună experiență
-            posibilă, care la randul ei va mări șansele ca{' '}
+            posibilă, care la randul ei va mări șansele ca
+            {' '}
             <a
               href="https://web.dev/site-speed-and-business-metrics/"
               target="_blank"
@@ -242,7 +267,8 @@ export default function ImagesLesson() {
           </LessonHeading>
           <blockquote>
             Most of the images on the web are downloaded, decoded and rendered
-            only never to be seen, as [...] the user never scrolled that far. -{' '}
+            only never to be seen, as [...] the user never scrolled that far. -
+            {' '}
             <small>
               <a
                 href="https://twitter.com/yoavweiss"
@@ -262,14 +288,21 @@ export default function ImagesLesson() {
             În background însă, browser-ul a încărcat toate imaginile, ceea ce e
             o risipă pentru că noi nu le-am văzut pe toate. Ideal ar fi să
             încărcăm imaginile
-            <strong> doar atunci când avem nevoie de ele </strong>.{/* , */}
+            <strong> doar atunci când avem nevoie de ele </strong>
+            .
+            {/* , */}
             {/* cum se întâmplă în video-ul din dreapta. */}
           </p>
           {/* TODO: video demo */}
           {/* <h1> VIDEO DEMO </h1> */}
           <p>
-            Pentru a rezolva această problemă vom folosi atributul{' '}
-            <strong>loading</strong> și valoarea <strong>lazy</strong>.
+            Pentru a rezolva această problemă vom folosi atributul
+            {' '}
+            <strong>loading</strong>
+            {' '}
+            și valoarea
+            <strong>lazy</strong>
+            .
           </p>
           <Highlight
             className="my-5"
@@ -284,10 +317,15 @@ export default function ImagesLesson() {
           />
           <p>
             Acum browserul va descărca imaginea doar când ne
-            <em>"apropiem"</em> de ea. Fiecare browser are propriile metrici
+            <em>"apropiem"</em>
+            {' '}
+            de ea. Fiecare browser are propriile metrici
             legate de ce înseamnă această apropiere, însă nu trebuie să ne batem
-            capul cu asta. Regula generală e să adăugăm atributul{' '}
-            <FormattedText as="strong">loading="lazy"</FormattedText> dacă avem
+            capul cu asta. Regula generală e să adăugăm atributul
+            {' '}
+            <FormattedText as="strong">loading="lazy"</FormattedText>
+            {' '}
+            dacă avem
             multe imagini în pagină.
           </p>
         </section>
@@ -298,8 +336,10 @@ export default function ImagesLesson() {
           <p>
             Am pornit de la imagini simple, am optimizat experiența folosind
             atributele width/height iar apoi am reușit să incărcăm doar
-            imaginile de care avem nevoie folosind atributul{' '}
-            <FormattedText as="strong">loading</FormattedText>. Acum e momentul
+            imaginile de care avem nevoie folosind atributul
+            {' '}
+            <FormattedText as="strong">loading</FormattedText>
+            . Acum e momentul
             să mergem un pas mai departe în călătoria spre performanță și să
             încărcăm imaginea cea mai potrivită din punct de vedere al
             rezoluției.
@@ -349,7 +389,10 @@ export default function ImagesLesson() {
             </LessonHeading>
             <p>
               Din fericire putem rezolva această problemă folosindu-ne de
-              atributul <strong>srcset</strong>. Hai să luăm imaginea noastră și
+              atributul
+              {' '}
+              <strong>srcset</strong>
+              . Hai să luăm imaginea noastră și
               să facem resize la 3 rezoluții diferite:
             </p>
             <LessonFigure
@@ -358,8 +401,13 @@ export default function ImagesLesson() {
               alt="Aceeași imagine în 3 dimensiuni diferite"
             />
             <LessonTip>
-              Pe Windows putem face resize cu <strong>Paint</strong> iar pe
-              MacOS folosind{' '}
+              Pe Windows putem face resize cu
+              {' '}
+              <strong>Paint</strong>
+              {' '}
+              iar pe
+              MacOS folosind
+              {' '}
               <strong>
                 <a
                   href="https://support.apple.com/guide/preview/resize-rotate-or-flip-an-image-prvw2015/mac"
@@ -368,11 +416,16 @@ export default function ImagesLesson() {
                 >
                   Preview App
                 </a>
-              </strong>{' '}
+              </strong>
+              {' '}
               .
             </LessonTip>
             <p>
-              Apoi vom adăuga atributul <strong>srcset</strong> unde definim
+              Apoi vom adăuga atributul
+              {' '}
+              <strong>srcset</strong>
+              {' '}
+              unde definim
               diferitele surse ale imaginii împreună cu dimensiunea (în lățime)
               a fiecăreia:
             </p>
@@ -404,9 +457,15 @@ export default function ImagesLesson() {
             Astfel ne asiguram ca imaginile nu vor iesi din pagina.
           </LessonTip> */}
             <p>
-              Șiiii voilà. Dacă mergem în{' '}
-              <a href="/intro/devtools">modul responsive</a> - și ținem tabul{' '}
-              <strong>network</strong> deschis vom observa cum diferite surse
+              Șiiii voilà. Dacă mergem în
+              {' '}
+              <a href="/intro/devtools">modul responsive</a>
+              {' '}
+              - și ținem tabul
+              {' '}
+              <strong>network</strong>
+              {' '}
+              deschis vom observa cum diferite surse
               ale imaginii se încarcă la rezoluții diferite.
             </p>
             <LessonFigure
@@ -417,12 +476,17 @@ export default function ImagesLesson() {
               alt="Diferite surse ale imaginii se încarcă la rezoluții diferite"
             />
             <p>
-              Te încurajăm să experimentezi și cu opțiunea{' '}
+              Te încurajăm să experimentezi și cu opțiunea
+              {' '}
               <Link href="intro/devtools">
                 <a target="_blank">DRP (Device Pixel Ratio)</a>
-              </Link>{' '}
+              </Link>
+              {' '}
               De exemplu, cu o valoare de 2 și o lățime de 650px se va incărca
-              imaginea <strong>red_bycicle__med.jpg</strong>.
+              imaginea
+              {' '}
+              <strong>red_bycicle__med.jpg</strong>
+              .
             </p>
           </section>
           <section>
@@ -431,13 +495,20 @@ export default function ImagesLesson() {
             </LessonHeading>
             <p>
               Până de curând singurul mod de a face imaginile din CSS (cele puse
-              prin <FormattedText as="strong">background-image:</FormattedText>{' '}
-              ) responsive a fost să punem mai multe reguli{' '}
-              <FormattedText as="strong">@media-query</FormattedText> și să
+              prin
+              {' '}
+              <FormattedText as="strong">background-image:</FormattedText>
+              {' '}
+              ) responsive a fost să punem mai multe reguli
+              {' '}
+              <FormattedText as="strong">@media-query</FormattedText>
+              {' '}
+              și să
               specificăm pentru fiecare o altă imagine.
             </p>
             <p>
-              Dar odată cu introducerea proprietății{' '}
+              Dar odată cu introducerea proprietății
+              {' '}
               <a
                 target="_blank"
                 className="text-bold"
@@ -445,7 +516,8 @@ export default function ImagesLesson() {
                 rel="noreferrer"
               >
                 image-set()
-              </a>{' '}
+              </a>
+              {' '}
               putem lăsa browserul să aleagă cea mai bună imagine în funcție de
               rezoluția ecranului:
             </p>
@@ -471,8 +543,11 @@ export default function ImagesLesson() {
             />
             <LessonTip icon={faQuestion}>
               Această proprietate nu are încă suport nativ în toate Browserele,
-              așa că în exemplul de mai sus am prefixat regulat cu{' '}
-              <FormattedText as="span">-webkit</FormattedText> pentru a
+              așa că în exemplul de mai sus am prefixat regulat cu
+              {' '}
+              <FormattedText as="span">-webkit</FormattedText>
+              {' '}
+              pentru a
               funcționa și în Chrome sau Safari.
             </LessonTip>
           </section>
@@ -482,20 +557,36 @@ export default function ImagesLesson() {
             {'Elementul <picture>'}
           </LessonHeading>
           <p>
-            După cum ai văzut până acum, elementul{' '}
-            <FormattedText as="strong">{'<img>'}</FormattedText> - deși destul
+            După cum ai văzut până acum, elementul
+            {' '}
+            <FormattedText as="strong">{'<img>'}</FormattedText>
+            {' '}
+            - deși destul
             de simplu în utilizare - ne oferă mai multe funcționalități care ne
             permit să optimizăm imaginile și experiența utilizatorilor. Cu toate
             acestea, a mai rămas totuși o ultimă optimizare, și anume folosirea
             unor formate moderne pentru imagini.
           </p>
           <blockquote>
-            De ce am vrea alte formate? Nu sunt <strong>JPG</strong> sau{' '}
-            <strong>PNG</strong> de ajuns?
+            De ce am vrea alte formate? Nu sunt
+            {' '}
+            <strong>JPG</strong>
+            {' '}
+            sau
+            {' '}
+            <strong>PNG</strong>
+            {' '}
+            de ajuns?
           </blockquote>
           <p>
-            Hmmm.... nu chiar. Există formate mai moderne precum{' '}
-            <strong>WebP</strong> sau <strong>AVIF</strong> care oferă aceeași
+            Hmmm.... nu chiar. Există formate mai moderne precum
+            {' '}
+            <strong>WebP</strong>
+            {' '}
+            sau
+            <strong>AVIF</strong>
+            {' '}
+            care oferă aceeași
             calitate a imaginii la o dimensiune mai mică. Uite diferențele de
             dimensiune ale acestei imagini în funcție de format:
           </p>
@@ -507,7 +598,8 @@ export default function ImagesLesson() {
             formate.
           </p>
           <p>
-            După cum vedem pe{' '}
+            După cum vedem pe
+            {' '}
             <a href="https://CanIUse.com" target="_blank" rel="noreferrer">
               Can I use...
             </a>
@@ -531,15 +623,26 @@ export default function ImagesLesson() {
             }}
           />
           <p>
-            Deci avem nevoie de o modalitate prin care browsere care înțeleg{' '}
-            <strong>WebP</strong> sau <strong> Avif</strong> să descarce aceste
+            Deci avem nevoie de o modalitate prin care browsere care înțeleg
+            {' '}
+            <strong>WebP</strong>
+            {' '}
+            sau
+            <strong> Avif</strong>
+            {' '}
+            să descarce aceste
             formate, în timp ce celelalte să rămână la JPG. Această tehnică se
-            numește general{' '}
-            <a href="/concepte/graceful-degradation">graceful degradation</a>.
+            numește general
+            {' '}
+            <a href="/concepte/graceful-degradation">graceful degradation</a>
+            .
           </p>
           <p>
-            Thankfully, această soluție ne este permisă de tag-ul{' '}
-            <FormattedText as="strong">{'<picture>'}</FormattedText> , unde
+            Thankfully, această soluție ne este permisă de tag-ul
+            {' '}
+            <FormattedText as="strong">{'<picture>'}</FormattedText>
+            {' '}
+            , unde
             putem specifica mai multe surse pentru o imagine și să lăsăm
             browserul să o aleagă pe cea pe care o înțelege.
           </p>
@@ -581,25 +684,42 @@ export default function ImagesLesson() {
           />
         </section>
         <p>
-          Ordinea elementelor{' '}
-          <FormattedText as="strong">{'<source>'}</FormattedText> este extrem de
+          Ordinea elementelor
+          {' '}
+          <FormattedText as="strong">{'<source>'}</FormattedText>
+          {' '}
+          este extrem de
           importantă căci browserul le va parcurge de sus-in-jos și o va alege
           pe prima compatibilă. De asemenea, în fiecare dintre ele trebuie
-          adăugat - via atributul <strong>srcset</strong> - mai multe surse de
+          adăugat - via atributul
+          <strong>srcset</strong>
+          {' '}
+          - mai multe surse de
           dimensiuni diferite. Astfel browserul nu alege numai formatul cel mai
           bun, cât și dimensiunea optimă a imaginii. Best of both worlds! 💪
         </p>
         <p>
-          PS: poate ai observat acel ultim{' '}
-          <FormattedText as="strong">{'<img>'}</FormattedText> tag. Ei bine,
+          PS: poate ai observat acel ultim
+          {' '}
+          <FormattedText as="strong">{'<img>'}</FormattedText>
+          {' '}
+          tag. Ei bine,
           avem nevoie de el pentru a specifica descrierea imaginii - în caz că
           aceasta nu poate fi încărcată, cât și pentru eventuala adaugare a unor
-          atribute extra - cum ar fi <strong>loading</strong>. Iar în cazurile
+          atribute extra - cum ar fi
+          <strong>loading</strong>
+          . Iar în cazurile
           mai rare în care utilizatorii folosesc browsere destul de vechi, ce nu
-          înțeleg elementul{' '}
-          <FormattedText as="strong">{'<picture>'}</FormattedText> , acestea vor
-          înțelege totuși tag-ul{' '}
-          <FormattedText as="strong">{'<img>'}</FormattedText> și îl vor arăta
+          înțeleg elementul
+          {' '}
+          <FormattedText as="strong">{'<picture>'}</FormattedText>
+          {' '}
+          , acestea vor
+          înțelege totuși tag-ul
+          {' '}
+          <FormattedText as="strong">{'<img>'}</FormattedText>
+          {' '}
+          și îl vor arăta
           pe acesta.
         </p>
         <div className="dots" />

--- a/client/curriculum/html/LinksAndButtons.tsx
+++ b/client/curriculum/html/LinksAndButtons.tsx
@@ -17,6 +17,7 @@ import { Diana } from '~/services/contributors';
 import Highlight from '~/components/Highlight/Highlight';
 import coverSvg from '~/public/images/lessons/links-and-buttons/cover.svg';
 import BasicEditorLazy from '~/components/Editor/BasicEditor/BasicEditor.lazy';
+import FormattedText from '~/components/FormattedText';
 
 const contributors = [Diana];
 const chapters = [
@@ -81,35 +82,21 @@ export default function LinksAndButtonsLesson() {
           link-uri în loc de butoane și invers.
         </p>
         <p>
-          Astfel, la sfârșitul articolului vom ști exact cum
-          să implementăm un UX corect folosind cele 2 elemente.
+          Astfel, la sfârșitul articolului vom ști exact cum să implementăm un
+          UX corect folosind cele 2 elemente.
         </p>
         <section>
           <LessonHeading as="h2" id="a-element">
             {'<a> element'}
           </LessonHeading>
           <p>
-            Elementul
-            {' '}
-            <strong className="formatted">{'<a>'}</strong>
-            {' '}
-            denumit și
-            {' '}
-            <i>ancoră</i>
-            {' '}
-            sau
-            {' '}
-            <i>link</i>
-            {' '}
-            este unul din cele mai uzuale elemente folosite pentru
-            construirea paginilor web. Dacă vrem să ne mutam la o altă pagină
-            sau la o altă zonă în cadrul aceleiași pagini, atunci vom folosi
-            acest element. Pentru a specifica destinația link-ului vom folosi
-            atributul
-            {' '}
-            <strong className="formatted">href</strong>
-            {' '}
-            .
+            Elementul <FormattedText as="strong">{'<a>'}</FormattedText> denumit
+            și <i>ancoră</i> sau <i>link</i> este unul din cele mai uzuale
+            elemente folosite pentru construirea paginilor web. Dacă vrem să ne
+            mutam la o altă pagină sau la o altă zonă în cadrul aceleiași
+            pagini, atunci vom folosi acest element. Pentru a specifica
+            destinația link-ului vom folosi atributul{' '}
+            <FormattedText as="strong">href</FormattedText> .
           </p>
         </section>
         <section>
@@ -126,33 +113,17 @@ export default function LinksAndButtonsLesson() {
 <a href="https://frontend.ro/"> Frontend.ro </a>`}
           />
           <p>
-            În cazul acesta, spunem că este un
-            {' '}
-            <strong>link către un URL absolut</strong>
-            {' '}
-            - adică un URL care
+            În cazul acesta, spunem că este un{' '}
+            <strong>link către un URL absolut</strong> - adică un URL care
             conține întreaga adresă a unei pagini. Acest tip de URL este deseori
             întâlnit atunci când un website face legătura către un alt website.
           </p>
           <p>
-            Putem avea și
-            {' '}
-            <strong>URL-uri relative</strong>
-            ,
-            a căror destinție finală se calculează în funcție de
-            pagina pe cară ne aflăm. În exemplul de mai jos avem același
-            link atât în
-            {' '}
-            <strong className="formatted">
-              about.html
-            </strong>
-            {' '}
-            cât și în
-            {' '}
-            <strong className="formatted">
-              home.html
-            </strong>
-            :
+            Putem avea și <strong>URL-uri relative</strong>, a căror destinție
+            finală se calculează în funcție de pagina pe cară ne aflăm. În
+            exemplul de mai jos avem același link atât în{' '}
+            <FormattedText as="strong">about.html</FormattedText> cât și în{' '}
+            <FormattedText as="strong">home.html</FormattedText>:
           </p>
           <Highlight
             language="html"
@@ -160,17 +131,15 @@ export default function LinksAndButtonsLesson() {
 <a href="info.html"> Go to info page </a>`}
           />
           <p>
-            Totuși, ajungem la destinații diferite în funcție de pagina
-            pe care suntem.
+            Totuși, ajungem la destinații diferite în funcție de pagina pe care
+            suntem.
           </p>
 
           <BasicEditorLazy folderStructure={relativeUrlExample} readOnly />
           <p>
             Foarte utile sunt și link-urile care duc către o secțiune ale
-            aceleiași pagini sau așa numitele
-            {' '}
-            <strong className="formatted">jump links</strong>
-            .
+            aceleiași pagini sau așa numitele{' '}
+            <FormattedText as="strong">jump links</FormattedText>.
           </p>
           <Highlight
             className="my-5"
@@ -183,19 +152,16 @@ export default function LinksAndButtonsLesson() {
 <!-- ... -->`}
           />
           <LessonTip>
-            Observați atributul
-            {' '}
-            <strong className="formatted">id</strong>
-            .
+            Observați atributul <FormattedText as="strong">id</FormattedText>.
             Aceasta este modalitatea prin care facem legătura între link și
             secțiunea paginii la care vrem să ajungem.
           </LessonTip>
           <p>
             Deși nu am ajuns la partea de CSS, merită menționat că jump links
-            pot să beneficieze de
-            {' '}
-            <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior">smooth scrolling</a>
-            {' '}
+            pot să beneficieze de{' '}
+            <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior">
+              smooth scrolling
+            </a>{' '}
             pentru ca utilizatorii să aibă o experiență mai plăcută:
           </p>
           <LessonFigure
@@ -211,16 +177,10 @@ export default function LinksAndButtonsLesson() {
             Link-uri către email-uri
           </LessonHeading>
           <p>
-            Sunt situații în care vrem să oferim unui utilizator posibilitatea de a
-            {' '}
-            <strong>
-              deschide email-ul precompletat către o adresă
-            </strong>
-            . În cazul acesta ne
-            vom folosi de
-            {' '}
-            <strong className="formatted">mailto</strong>
-            :
+            Sunt situații în care vrem să oferim unui utilizator posibilitatea
+            de a <strong>deschide email-ul precompletat către o adresă</strong>.
+            În cazul acesta ne vom folosi de{' '}
+            <FormattedText as="strong">mailto</FormattedText> :
           </p>
           <Highlight
             className="my-5"
@@ -232,10 +192,8 @@ export default function LinksAndButtonsLesson() {
           />
           <p>
             Apasă pe linkul alăturat și ți se va deschide clientul de email,
-            precompletat cu adresa noastră 👉
-            {' '}
-            <a href="mailto:hello@frontend.ro">Trimite email la Frontend.ro</a>
-            .
+            precompletat cu adresa noastră 👉{' '}
+            <a href="mailto:hello@frontend.ro">Trimite email la Frontend.ro</a>.
           </p>
           <LessonFigure
             isVideo
@@ -247,9 +205,9 @@ export default function LinksAndButtonsLesson() {
             Link-uri către numere de telefon
           </LessonHeading>
           <p>
-            Mai mult, dacă vrem să arătăm în pagină
-            numere de telefon e recomandat să folosim link-uri,
-            pentru a ne deschide direct aplicația prin care sunăm:
+            Mai mult, dacă vrem să arătăm în pagină numere de telefon e
+            recomandat să folosim link-uri, pentru a ne deschide direct
+            aplicația prin care sunăm:
           </p>
           <Highlight
             className="my-5"
@@ -261,7 +219,8 @@ export default function LinksAndButtonsLesson() {
           />
           <p>
             Apasă pe unul din numerele de mai jos pentru a vedea cum sunt
-            precompletate pe telefon (poți să dai click fără griji, nu le vei apela dacă faci asta)
+            precompletate pe telefon (poți să dai click fără griji, nu le vei
+            apela dacă faci asta)
           </p>
           <ul className="with--bullets">
             <li>
@@ -281,11 +240,8 @@ export default function LinksAndButtonsLesson() {
             Link-uri de download
           </LessonHeading>
           <p>
-            Împreuna cu atributul
-            {' '}
-            <strong className="formatted">download</strong>
-            {' '}
-            putem instrui
+            Împreuna cu atributul{' '}
+            <FormattedText as="strong">download</FormattedText> putem instrui
             browser-ul să downloadeze fișierul din cadrul link-ului în loc să îl
             deschidă în pagina curentă:
           </p>
@@ -297,8 +253,7 @@ export default function LinksAndButtonsLesson() {
 `}
           />
           <p>
-            Apasă pe linkul de alături pentru a downlada logo-ul nostru 👉
-            {' '}
+            Apasă pe linkul de alături pentru a downlada logo-ul nostru 👉{' '}
             <a href="/logo.png" download>
               Downloadează logo-ul nostru
             </a>
@@ -306,8 +261,8 @@ export default function LinksAndButtonsLesson() {
           <p>
             Acum că ne-am familiarizat cu situații din practică unde putem
             folosi link-uri, ne-am obișnuit puțin cu markup-ul și cu câteva
-            dintre atributele ce pot însoți elementul, putem să
-            vorbim de câteva bune practici pe care să le avem în vedere.
+            dintre atributele ce pot însoți elementul, putem să vorbim de câteva
+            bune practici pe care să le avem în vedere.
           </p>
         </section>
         <section>
@@ -315,32 +270,17 @@ export default function LinksAndButtonsLesson() {
             Atributul target=”_blank”
           </LessonHeading>
           <p>
-            În afară de atributele prezentate, un alt atribut des folosit este
-            {' '}
-            <strong className="formatted"> target</strong>
-            {' '}
-            , care ne indică cum
-            să deschidem link-ul din href.
+            În afară de atributele prezentate, un alt atribut des folosit este{' '}
+            <FormattedText as="strong"> target</FormattedText> , care ne indică
+            cum să deschidem link-ul din href.
           </p>
           <p>
-            Ca și developeri cel mai des ne vom întâlni cu situația de a folosi
-            {' '}
-            <strong className="formatted">
-              target="_blank"
-            </strong>
-            {' '}
-            (link-ul va fi deschis într-o fereastră sau un tab
-            nou)
-            .
-            Când folosim valoarea
-            {' '}
-            <strong>_blank</strong>
-            , e recomandat să adăugăm un nou atribut
-            pentru securitate și anume :
-            {' '}
-            <strong className="formatted">
-              rel=”noopener noreferrer”
-            </strong>
+            Ca și developeri cel mai des ne vom întâlni cu situația de a folosi{' '}
+            <FormattedText as="strong">target="_blank"</FormattedText> (link-ul
+            va fi deschis într-o fereastră sau un tab nou) . Când folosim
+            valoarea <strong>_blank</strong>, e recomandat să adăugăm un nou
+            atribut pentru securitate și anume :{' '}
+            <FormattedText as="strong">rel=”noopener noreferrer”</FormattedText>
             .
           </p>
           <Highlight
@@ -353,8 +293,7 @@ export default function LinksAndButtonsLesson() {
             `}
           />
           <p>
-            Apasă pe următorul link pentru a-l deschide într-un nou tab 👉
-            {' '}
+            Apasă pe următorul link pentru a-l deschide într-un nou tab 👉{' '}
             <a
               href="http://frontend.ro"
               target="_blank"
@@ -374,22 +313,15 @@ export default function LinksAndButtonsLesson() {
             diverse situații:
           </p>
           <blockquote>
-            Putem folosi doar un
-            {' '}
-            <strong className="formatted">icon</strong>
-            {' '}
-            în
-            interiorul unui link?
+            Putem folosi doar un <FormattedText as="strong">icon</FormattedText>{' '}
+            în interiorul unui link?
           </blockquote>
           <p>
-            Din păcate un simplu icon nu ne-ar oferi suficientă
-            informație contextuală despre link, deci nu ar fi chiar recomandat.
-            Dacă totuși suntem nevoiți să folosim un astfel de icon, o bună
-            practică ar fi să adăugăm în link niște text
-            ascuns vizual, care va fi totuși citit de
-            {' '}
-            <strong>screen readers</strong>
-            :
+            Din păcate un simplu icon nu ne-ar oferi suficientă informație
+            contextuală despre link, deci nu ar fi chiar recomandat. Dacă totuși
+            suntem nevoiți să folosim un astfel de icon, o bună practică ar fi
+            să adăugăm în link niște text ascuns vizual, care va fi totuși citit
+            de <strong>screen readers</strong>:
           </p>
           <Highlight
             className="my-5"
@@ -410,10 +342,9 @@ export default function LinksAndButtonsLesson() {
  </a>`}
           />
           <p>
-            Spre exemplu, link-ul alăturat conține doar un icon pentru un coș de cumpărături,
-            dar e în același timp
-            accesibil pentru cei ce folosesc screen readere 👉:
-            {' '}
+            Spre exemplu, link-ul alăturat conține doar un icon pentru un coș de
+            cumpărături, dar e în același timp accesibil pentru cei ce folosesc
+            screen readere 👉:{' '}
             <a href="https://fontawesome.com/">
               <svg width="24" height="24" viewBox="0 0 1024 1024">
                 <g>
@@ -429,22 +360,13 @@ export default function LinksAndButtonsLesson() {
             </a>
           </p>
           <LessonTip icon={faQuestionCircle}>
-            Atributul
-            {' '}
-            <strong className="formatted">style</strong>
-            {' '}
-            este folosit
-            pentru a adăuga reguli CSS elementelor. Încă nu am ajuns la acel
-            capitol deci e ok dacă nu știi cum să-l folosești.
-            Totuși, te rugăm să-l păstrezi în exemplu, pentu a funcționa
-            cum ne așteptăm.
+            Atributul <FormattedText as="strong">style</FormattedText> este
+            folosit pentru a adăuga reguli CSS elementelor. Încă nu am ajuns la
+            acel capitol deci e ok dacă nu știi cum să-l folosești. Totuși, te
+            rugăm să-l păstrezi în exemplu, pentu a funcționa cum ne așteptăm.
           </LessonTip>
           <blockquote>
-            Putem folosi o
-            {' '}
-            <strong className="formatted">imagine</strong>
-            {' '}
-            în
+            Putem folosi o <FormattedText as="strong">imagine</FormattedText> în
             interiorul unui link?
           </blockquote>
           <p>
@@ -464,9 +386,8 @@ export default function LinksAndButtonsLesson() {
 </a>`}
           />
           <p>
-            Alături avem o imagine într-un link. Dacă dăm click pe ea,
-            ne va duce pa pagina principală (home page) 👉
-            {' '}
+            Alături avem o imagine într-un link. Dacă dăm click pe ea, ne va
+            duce pa pagina principală (home page) 👉{' '}
             <a style={{ verticalAlign: 'middle' }} href="/">
               <img height="48" src="/logo.png" alt="Frontend.ro LOGO." />
             </a>
@@ -490,12 +411,10 @@ export default function LinksAndButtonsLesson() {
             {'<button> element'}
           </LessonHeading>
           <p>
-            Elementul html
-            {' '}
-            <strong className="formatted">{'<button>'}</strong>
-            {' '}
-            este folosit atunci când vrem să facem o acțiune (exemple: arată/ascunde
-            un meniu, play sau pause la un video, trimite un comentariu, etc)
+            Elementul html{' '}
+            <FormattedText as="strong">{'<button>'}</FormattedText> este folosit
+            atunci când vrem să facem o acțiune (exemple: arată/ascunde un
+            meniu, play sau pause la un video, trimite un comentariu, etc)
           </p>
           <Highlight
             language="html"
@@ -505,14 +424,11 @@ export default function LinksAndButtonsLesson() {
 </button>`}
           />
           <p>
-            Spre deosebire de link-uri, butoanele
-            {' '}
-            <strong>NU</strong>
-            {' '}
-            schimbă
-            pagina. Totuși dacă avem un formular cu un buton de login, dăm click pe
-            el, așteptăm, apoi suntem direcționați către o nouă pagină, putem
-            spune că acțiunea declanșată de buton a schimbat pagina. În cazul acesta e ok :)
+            Spre deosebire de link-uri, butoanele <strong>NU</strong> schimbă
+            pagina. Totuși dacă avem un formular cu un buton de login, dăm click
+            pe el, așteptăm, apoi suntem direcționați către o nouă pagină, putem
+            spune că acțiunea declanșată de buton a schimbat pagina. În cazul
+            acesta e ok :)
           </p>
         </section>
         <section>
@@ -525,21 +441,19 @@ export default function LinksAndButtonsLesson() {
           </p>
           <ul className="with--bullets">
             <li>
-              <strong className="formatted">type="button"</strong>
+              <FormattedText as="strong">type="button"</FormattedText>
             </li>
             <li>
-              <strong className="formatted">type="submit"</strong>
-              : (utilizate
-              în cadrul formularelor - vom discuta mai multe în momentul în care
-              vom ajunge la această lecție)
+              <FormattedText as="strong">type="submit"</FormattedText>:
+              (utilizate în cadrul formularelor - vom discuta mai multe în
+              momentul în care vom ajunge la această lecție)
             </li>
           </ul>
           <p>O bună practică este să specificăm mereu tipul acestora.</p>
           <p>
-            Pe lîngă submit și button, type mai pot avea și valoarea
-            {' '}
-            <strong className="formatted">reset</strong>
-            . Uite un exemplu care le include pe toate 3:
+            Pe lîngă submit și button, type mai pot avea și valoarea{' '}
+            <FormattedText as="strong">reset</FormattedText>. Uite un exemplu
+            care le include pe toate 3:
           </p>
           <Highlight
             className="my-5"
@@ -598,26 +512,18 @@ export default function LinksAndButtonsLesson() {
             demo="/demo/html/butoane-atributul-disabled"
           /> */}
           <ol style={{ listStyle: 'revert' }}>
+            <li>completăm formularul</li>
+            <li>apăsăm butonul de login</li>
             <li>
-              completăm formularul
-            </li>
-            <li>
-              apăsăm butonul de login
-            </li>
-            <li>
-              butonul devinde
-              {' '}
-              <strong> disabled </strong>
-              {' '}
-              cât timp
-              se trimit datele la server și se așteaptă un răspuns
-              (pentru a preveni cazul în care utilizatorul încearcă
-              din nou în timp ce autentificarea e înca în proges)
+              butonul devinde <strong> disabled </strong> cât timp se trimit
+              datele la server și se așteaptă un răspuns (pentru a preveni cazul
+              în care utilizatorul încearcă din nou în timp ce autentificarea e
+              înca în proges)
             </li>
             <li>
               dacă logarea eșuează, putem afișa un mesaj informativ în care să
-              explicăm de ce nu a putut avea loc și să facem enabled la buton abia
-              la final, pentru a reîncerca.
+              explicăm de ce nu a putut avea loc și să facem enabled la buton
+              abia la final, pentru a reîncerca.
             </li>
           </ol>
           <LessonFigure
@@ -657,11 +563,13 @@ export default function LinksAndButtonsLesson() {
             },
             {
               text: 'Valoarea "noreferrer" pentru atributul "rel"',
-              url: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noreferrer',
+              url:
+                'https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noreferrer',
             },
             {
               text: 'Valoarea "noopener" pentru atributul "rel"',
-              url: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener',
+              url:
+                'https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/noopener',
             },
           ]}
         />
@@ -672,13 +580,15 @@ export default function LinksAndButtonsLesson() {
 
 const relativeUrlExample = {
   files: [],
-  folders: [{
-    key: 'home',
-    name: 'home',
-    files: [{
-      key: 'home.html',
-      name: 'home.html',
-      content: `<!DOCTYPE html>
+  folders: [
+    {
+      key: 'home',
+      name: 'home',
+      files: [
+        {
+          key: 'home.html',
+          name: 'home.html',
+          content: `<!DOCTYPE html>
 <html>
 <head>
   <title>Url relativ</title>
@@ -689,10 +599,11 @@ const relativeUrlExample = {
 </body>
 </html>
       `,
-    }, {
-      key: 'info.html',
-      name: 'info.html',
-      content: `<!DOCTYPE html>
+        },
+        {
+          key: 'info.html',
+          name: 'info.html',
+          content: `<!DOCTYPE html>
 <html>
 <head>
   <title>Info | Home page</title>
@@ -702,16 +613,19 @@ const relativeUrlExample = {
 </body>
 </html>
 `,
-    }],
-    folders: [],
-  }, {
-    key: 'about',
-    name: 'about',
-    folders: [],
-    files: [{
-      key: 'about.html',
-      name: 'about.html',
-      content: `<!DOCTYPE html>
+        },
+      ],
+      folders: [],
+    },
+    {
+      key: 'about',
+      name: 'about',
+      folders: [],
+      files: [
+        {
+          key: 'about.html',
+          name: 'about.html',
+          content: `<!DOCTYPE html>
 <html>
 <head>
   <title>Url relativ</title>
@@ -722,10 +636,11 @@ const relativeUrlExample = {
 </body>
 </html>
 `,
-    }, {
-      key: 'info.html',
-      name: 'info.html',
-      content: `<!DOCTYPE html>
+        },
+        {
+          key: 'info.html',
+          name: 'info.html',
+          content: `<!DOCTYPE html>
 <html>
 <head>
   <title>Info | About page</title>
@@ -735,6 +650,8 @@ const relativeUrlExample = {
 </body>
 </html>
 `,
-    }],
-  }],
+        },
+      ],
+    },
+  ],
 };

--- a/client/curriculum/html/LinksAndButtons.tsx
+++ b/client/curriculum/html/LinksAndButtons.tsx
@@ -90,13 +90,28 @@ export default function LinksAndButtonsLesson() {
             {'<a> element'}
           </LessonHeading>
           <p>
-            Elementul <FormattedText as="strong">{'<a>'}</FormattedText> denumit
-            și <i>ancoră</i> sau <i>link</i> este unul din cele mai uzuale
+            Elementul
+            {' '}
+            <FormattedText as="strong">{'<a>'}</FormattedText>
+            {' '}
+            denumit
+            și
+            {' '}
+            <i>ancoră</i>
+            {' '}
+            sau
+            {' '}
+            <i>link</i>
+            {' '}
+            este unul din cele mai uzuale
             elemente folosite pentru construirea paginilor web. Dacă vrem să ne
             mutam la o altă pagină sau la o altă zonă în cadrul aceleiași
             pagini, atunci vom folosi acest element. Pentru a specifica
-            destinația link-ului vom folosi atributul{' '}
-            <FormattedText as="strong">href</FormattedText> .
+            destinația link-ului vom folosi atributul
+            {' '}
+            <FormattedText as="strong">href</FormattedText>
+            {' '}
+            .
           </p>
         </section>
         <section>
@@ -113,17 +128,28 @@ export default function LinksAndButtonsLesson() {
 <a href="https://frontend.ro/"> Frontend.ro </a>`}
           />
           <p>
-            În cazul acesta, spunem că este un{' '}
-            <strong>link către un URL absolut</strong> - adică un URL care
+            În cazul acesta, spunem că este un
+            {' '}
+            <strong>link către un URL absolut</strong>
+            {' '}
+            - adică un URL care
             conține întreaga adresă a unei pagini. Acest tip de URL este deseori
             întâlnit atunci când un website face legătura către un alt website.
           </p>
           <p>
-            Putem avea și <strong>URL-uri relative</strong>, a căror destinție
+            Putem avea și
+            {' '}
+            <strong>URL-uri relative</strong>
+            , a căror destinție
             finală se calculează în funcție de pagina pe cară ne aflăm. În
-            exemplul de mai jos avem același link atât în{' '}
-            <FormattedText as="strong">about.html</FormattedText> cât și în{' '}
-            <FormattedText as="strong">home.html</FormattedText>:
+            exemplul de mai jos avem același link atât în
+            {' '}
+            <FormattedText as="strong">about.html</FormattedText>
+            {' '}
+            cât și în
+            {' '}
+            <FormattedText as="strong">home.html</FormattedText>
+            :
           </p>
           <Highlight
             language="html"
@@ -138,8 +164,10 @@ export default function LinksAndButtonsLesson() {
           <BasicEditorLazy folderStructure={relativeUrlExample} readOnly />
           <p>
             Foarte utile sunt și link-urile care duc către o secțiune ale
-            aceleiași pagini sau așa numitele{' '}
-            <FormattedText as="strong">jump links</FormattedText>.
+            aceleiași pagini sau așa numitele
+            {' '}
+            <FormattedText as="strong">jump links</FormattedText>
+            .
           </p>
           <Highlight
             className="my-5"
@@ -152,16 +180,21 @@ export default function LinksAndButtonsLesson() {
 <!-- ... -->`}
           />
           <LessonTip>
-            Observați atributul <FormattedText as="strong">id</FormattedText>.
+            Observați atributul
+            {' '}
+            <FormattedText as="strong">id</FormattedText>
+            .
             Aceasta este modalitatea prin care facem legătura între link și
             secțiunea paginii la care vrem să ajungem.
           </LessonTip>
           <p>
             Deși nu am ajuns la partea de CSS, merită menționat că jump links
-            pot să beneficieze de{' '}
+            pot să beneficieze de
+            {' '}
             <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior">
               smooth scrolling
-            </a>{' '}
+            </a>
+            {' '}
             pentru ca utilizatorii să aibă o experiență mai plăcută:
           </p>
           <LessonFigure
@@ -178,9 +211,15 @@ export default function LinksAndButtonsLesson() {
           </LessonHeading>
           <p>
             Sunt situații în care vrem să oferim unui utilizator posibilitatea
-            de a <strong>deschide email-ul precompletat către o adresă</strong>.
-            În cazul acesta ne vom folosi de{' '}
-            <FormattedText as="strong">mailto</FormattedText> :
+            de a
+            {' '}
+            <strong>deschide email-ul precompletat către o adresă</strong>
+            .
+            În cazul acesta ne vom folosi de
+            {' '}
+            <FormattedText as="strong">mailto</FormattedText>
+            {' '}
+            :
           </p>
           <Highlight
             className="my-5"
@@ -192,8 +231,10 @@ export default function LinksAndButtonsLesson() {
           />
           <p>
             Apasă pe linkul alăturat și ți se va deschide clientul de email,
-            precompletat cu adresa noastră 👉{' '}
-            <a href="mailto:hello@frontend.ro">Trimite email la Frontend.ro</a>.
+            precompletat cu adresa noastră 👉
+            {' '}
+            <a href="mailto:hello@frontend.ro">Trimite email la Frontend.ro</a>
+            .
           </p>
           <LessonFigure
             isVideo
@@ -240,8 +281,11 @@ export default function LinksAndButtonsLesson() {
             Link-uri de download
           </LessonHeading>
           <p>
-            Împreuna cu atributul{' '}
-            <FormattedText as="strong">download</FormattedText> putem instrui
+            Împreuna cu atributul
+            {' '}
+            <FormattedText as="strong">download</FormattedText>
+            {' '}
+            putem instrui
             browser-ul să downloadeze fișierul din cadrul link-ului în loc să îl
             deschidă în pagina curentă:
           </p>
@@ -253,7 +297,8 @@ export default function LinksAndButtonsLesson() {
 `}
           />
           <p>
-            Apasă pe linkul de alături pentru a downlada logo-ul nostru 👉{' '}
+            Apasă pe linkul de alături pentru a downlada logo-ul nostru 👉
+            {' '}
             <a href="/logo.png" download>
               Downloadează logo-ul nostru
             </a>
@@ -270,16 +315,25 @@ export default function LinksAndButtonsLesson() {
             Atributul target=”_blank”
           </LessonHeading>
           <p>
-            În afară de atributele prezentate, un alt atribut des folosit este{' '}
-            <FormattedText as="strong"> target</FormattedText> , care ne indică
+            În afară de atributele prezentate, un alt atribut des folosit este
+            {' '}
+            <FormattedText as="strong"> target</FormattedText>
+            {' '}
+            , care ne indică
             cum să deschidem link-ul din href.
           </p>
           <p>
-            Ca și developeri cel mai des ne vom întâlni cu situația de a folosi{' '}
-            <FormattedText as="strong">target="_blank"</FormattedText> (link-ul
+            Ca și developeri cel mai des ne vom întâlni cu situația de a folosi
+            {' '}
+            <FormattedText as="strong">target="_blank"</FormattedText>
+            {' '}
+            (link-ul
             va fi deschis într-o fereastră sau un tab nou) . Când folosim
-            valoarea <strong>_blank</strong>, e recomandat să adăugăm un nou
-            atribut pentru securitate și anume :{' '}
+            valoarea
+            <strong>_blank</strong>
+            , e recomandat să adăugăm un nou
+            atribut pentru securitate și anume :
+            {' '}
             <FormattedText as="strong">rel=”noopener noreferrer”</FormattedText>
             .
           </p>
@@ -293,7 +347,8 @@ export default function LinksAndButtonsLesson() {
             `}
           />
           <p>
-            Apasă pe următorul link pentru a-l deschide într-un nou tab 👉{' '}
+            Apasă pe următorul link pentru a-l deschide într-un nou tab 👉
+            {' '}
             <a
               href="http://frontend.ro"
               target="_blank"
@@ -313,7 +368,10 @@ export default function LinksAndButtonsLesson() {
             diverse situații:
           </p>
           <blockquote>
-            Putem folosi doar un <FormattedText as="strong">icon</FormattedText>{' '}
+            Putem folosi doar un
+            {' '}
+            <FormattedText as="strong">icon</FormattedText>
+            {' '}
             în interiorul unui link?
           </blockquote>
           <p>
@@ -321,7 +379,10 @@ export default function LinksAndButtonsLesson() {
             contextuală despre link, deci nu ar fi chiar recomandat. Dacă totuși
             suntem nevoiți să folosim un astfel de icon, o bună practică ar fi
             să adăugăm în link niște text ascuns vizual, care va fi totuși citit
-            de <strong>screen readers</strong>:
+            de
+            {' '}
+            <strong>screen readers</strong>
+            :
           </p>
           <Highlight
             className="my-5"
@@ -344,7 +405,8 @@ export default function LinksAndButtonsLesson() {
           <p>
             Spre exemplu, link-ul alăturat conține doar un icon pentru un coș de
             cumpărături, dar e în același timp accesibil pentru cei ce folosesc
-            screen readere 👉:{' '}
+            screen readere 👉:
+            {' '}
             <a href="https://fontawesome.com/">
               <svg width="24" height="24" viewBox="0 0 1024 1024">
                 <g>
@@ -360,13 +422,21 @@ export default function LinksAndButtonsLesson() {
             </a>
           </p>
           <LessonTip icon={faQuestionCircle}>
-            Atributul <FormattedText as="strong">style</FormattedText> este
+            Atributul
+            {' '}
+            <FormattedText as="strong">style</FormattedText>
+            {' '}
+            este
             folosit pentru a adăuga reguli CSS elementelor. Încă nu am ajuns la
             acel capitol deci e ok dacă nu știi cum să-l folosești. Totuși, te
             rugăm să-l păstrezi în exemplu, pentu a funcționa cum ne așteptăm.
           </LessonTip>
           <blockquote>
-            Putem folosi o <FormattedText as="strong">imagine</FormattedText> în
+            Putem folosi o
+            {' '}
+            <FormattedText as="strong">imagine</FormattedText>
+            {' '}
+            în
             interiorul unui link?
           </blockquote>
           <p>
@@ -387,7 +457,8 @@ export default function LinksAndButtonsLesson() {
           />
           <p>
             Alături avem o imagine într-un link. Dacă dăm click pe ea, ne va
-            duce pa pagina principală (home page) 👉{' '}
+            duce pa pagina principală (home page) 👉
+            {' '}
             <a style={{ verticalAlign: 'middle' }} href="/">
               <img height="48" src="/logo.png" alt="Frontend.ro LOGO." />
             </a>
@@ -411,8 +482,11 @@ export default function LinksAndButtonsLesson() {
             {'<button> element'}
           </LessonHeading>
           <p>
-            Elementul html{' '}
-            <FormattedText as="strong">{'<button>'}</FormattedText> este folosit
+            Elementul html
+            {' '}
+            <FormattedText as="strong">{'<button>'}</FormattedText>
+            {' '}
+            este folosit
             atunci când vrem să facem o acțiune (exemple: arată/ascunde un
             meniu, play sau pause la un video, trimite un comentariu, etc)
           </p>
@@ -424,7 +498,11 @@ export default function LinksAndButtonsLesson() {
 </button>`}
           />
           <p>
-            Spre deosebire de link-uri, butoanele <strong>NU</strong> schimbă
+            Spre deosebire de link-uri, butoanele
+            {' '}
+            <strong>NU</strong>
+            {' '}
+            schimbă
             pagina. Totuși dacă avem un formular cu un buton de login, dăm click
             pe el, așteptăm, apoi suntem direcționați către o nouă pagină, putem
             spune că acțiunea declanșată de buton a schimbat pagina. În cazul
@@ -444,15 +522,18 @@ export default function LinksAndButtonsLesson() {
               <FormattedText as="strong">type="button"</FormattedText>
             </li>
             <li>
-              <FormattedText as="strong">type="submit"</FormattedText>:
+              <FormattedText as="strong">type="submit"</FormattedText>
+              :
               (utilizate în cadrul formularelor - vom discuta mai multe în
               momentul în care vom ajunge la această lecție)
             </li>
           </ul>
           <p>O bună practică este să specificăm mereu tipul acestora.</p>
           <p>
-            Pe lîngă submit și button, type mai pot avea și valoarea{' '}
-            <FormattedText as="strong">reset</FormattedText>. Uite un exemplu
+            Pe lîngă submit și button, type mai pot avea și valoarea
+            {' '}
+            <FormattedText as="strong">reset</FormattedText>
+            . Uite un exemplu
             care le include pe toate 3:
           </p>
           <Highlight
@@ -515,7 +596,11 @@ export default function LinksAndButtonsLesson() {
             <li>completăm formularul</li>
             <li>apăsăm butonul de login</li>
             <li>
-              butonul devinde <strong> disabled </strong> cât timp se trimit
+              butonul devinde
+              {' '}
+              <strong> disabled </strong>
+              {' '}
+              cât timp se trimit
               datele la server și se așteaptă un răspuns (pentru a preveni cazul
               în care utilizatorul încearcă din nou în timp ce autentificarea e
               înca în proges)

--- a/client/curriculum/html/Lists.tsx
+++ b/client/curriculum/html/Lists.tsx
@@ -45,6 +45,7 @@ export default function ListsLesson() {
         <LessonCover>
           {/* eslint-disable-next-line react/no-danger */}
           <div
+            // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: coverSvg,
             }}
@@ -67,12 +68,16 @@ export default function ListsLesson() {
           <p>Există două tipuri de liste des folosite în HTML:</p>
           <ul className="with--bullets">
             <li className="mb-4">
-              <FormattedText as="strong">Liste neordonate</FormattedText> -
+              <FormattedText as="strong">Liste neordonate</FormattedText>
+              {' '}
+              -
               utilizate pentru a grupa un set de elemente ce nu necesită o
               anumită ordine
             </li>
             <li>
-              <FormattedText as="strong">Liste ordonate</FormattedText> -
+              <FormattedText as="strong">Liste ordonate</FormattedText>
+              {' '}
+              -
               utilizate pentru a grupa un set de elemente ce au o ordine
               specifică
             </li>
@@ -110,17 +115,27 @@ export default function ListsLesson() {
           />
           <LessonTip>
             Observă cum ne folosim de 2 tipuri de elemente pentru a defini o
-            listă: în exterior avem{' '}
-            <FormattedText as="strong">{'<ul>'}</FormattedText> (unordered list)
-            pentru a defini lista, iar apoi fiecare element în propriul tag{' '}
-            <FormattedText as="strong">{'<li>'}</FormattedText> (list item) .
+            listă: în exterior avem
+            {' '}
+            <FormattedText as="strong">{'<ul>'}</FormattedText>
+            {' '}
+            (unordered list)
+            pentru a defini lista, iar apoi fiecare element în propriul tag
+            {' '}
+            <FormattedText as="strong">{'<li>'}</FormattedText>
+            {' '}
+            (list item) .
           </LessonTip>
           <p>
-            Cu o stilizare potrivită, listele neordonate sunt folosite la{' '}
-            <strong>realizarea meniurilor paginilor web</strong>.{' '}
+            Cu o stilizare potrivită, listele neordonate sunt folosite la
+            {' '}
+            <strong>realizarea meniurilor paginilor web</strong>
+            .
+            {' '}
             <a href="https://github.com" target="_blank" rel="noreferrer">
               GitHub
-            </a>{' '}
+            </a>
+            {' '}
             e un exemplu bun, ei folosind liste neordonate pentru meniul de
             navigare:
           </p>
@@ -162,8 +177,11 @@ export default function ListsLesson() {
           />
           <p>
             Acestea au o structura similară cu cele neordonate, singura
-            diferență fiind tag-ul:{' '}
-            <FormattedText as="strong">{'<ol>'}</FormattedText> (ordered list).
+            diferență fiind tag-ul:
+            {' '}
+            <FormattedText as="strong">{'<ol>'}</FormattedText>
+            {' '}
+            (ordered list).
             E evident că dacă vom schimba ordinea elementelor din cadrul listei,
             aceasta nu va mai avea nici un sens.
           </p>
@@ -180,26 +198,41 @@ export default function ListsLesson() {
           </LessonHeading>
           <p>
             Dacă vrem ca enumerarea elementelor din listă să se facă cu un
-            anumit tip de cifră sau cu litere, ne putem folosi de atributul{' '}
-            <FormattedText as="strong"> type</FormattedText>. Acesta acceptă ca
+            anumit tip de cifră sau cu litere, ne putem folosi de atributul
+            {' '}
+            <FormattedText as="strong"> type</FormattedText>
+            . Acesta acceptă ca
             valori:
           </p>
           <ul className="with--bullets">
             <li className="mb-4">
               {' '}
-              <FormattedText as="strong">1</FormattedText> – pentru enumerare cu{' '}
+              <FormattedText as="strong">1</FormattedText>
+              {' '}
+              – pentru enumerare cu
+              {' '}
               cifre arabe;
             </li>
             <li className="mb-4">
               {' '}
-              <FormattedText as="strong">i</FormattedText> sau{' '}
-              <FormattedText as="strong">I</FormattedText> – pentru enumerare cu
+              <FormattedText as="strong">i</FormattedText>
+              {' '}
+              sau
+              {' '}
+              <FormattedText as="strong">I</FormattedText>
+              {' '}
+              – pentru enumerare cu
               cifre romane mici, respectiv mari
             </li>
             <li className="mb-4">
               {' '}
-              <FormattedText as="strong">a</FormattedText> sau{' '}
-              <FormattedText as="strong">A</FormattedText> – pentru enumerare cu
+              <FormattedText as="strong">a</FormattedText>
+              {' '}
+              sau
+              {' '}
+              <FormattedText as="strong">A</FormattedText>
+              {' '}
+              – pentru enumerare cu
               litere mici, respectiv mari.
             </li>
           </ul>
@@ -222,8 +255,11 @@ export default function ListsLesson() {
           />
           <p>
             Dacă vrem ca lista să înceapă enumerarea de la cifra/litera cea mai
-            avansată și să se termine cu prima, vom folosi atributul{' '}
-            <FormattedText as="strong">reversed</FormattedText> .
+            avansată și să se termine cu prima, vom folosi atributul
+            {' '}
+            <FormattedText as="strong">reversed</FormattedText>
+            {' '}
+            .
           </p>
           <LessonFigure
             withBorder
@@ -233,8 +269,11 @@ export default function ListsLesson() {
           />
           <p>
             Putem opta chiar să enumerăm elementele unei liste ordonate începând
-            de la un anumit număr/literă. Pentru asta ne vom folosi de atributul{' '}
-            <FormattedText as="strong">start</FormattedText> dând ca valoare
+            de la un anumit număr/literă. Pentru asta ne vom folosi de atributul
+            {' '}
+            <FormattedText as="strong">start</FormattedText>
+            {' '}
+            dând ca valoare
             numărul sau litera de la care vrem sa începem numărătoarea:
           </p>
           <LessonFigure
@@ -289,8 +328,11 @@ export default function ListsLesson() {
           </LessonHeading>
           <p>
             Există și un al treilea tip de listă pe care-l vei întâlni mai rar
-            dar e totuși bine să-l știi:{' '}
-            <FormattedText as="strong">{'<dl>'}</FormattedText> (description
+            dar e totuși bine să-l știi:
+            {' '}
+            <FormattedText as="strong">{'<dl>'}</FormattedText>
+            {' '}
+            (description
             list). Îl vom folosi când definim termeni sau asociem perechi de
             valori, ca în exemplul de mai jos:
           </p>
@@ -325,7 +367,8 @@ export default function ListsLesson() {
             </dt>
             <dd className="mb-4">
               {' '}
-              Dacă da, vom folosi o listă de descrieri.{' '}
+              Dacă da, vom folosi o listă de descrieri.
+              {' '}
             </dd>
 
             <dt className="text-bold">
@@ -334,12 +377,21 @@ export default function ListsLesson() {
             <dd>
               {' '}
               Dacă da, folosim o listă ordonată, altfel vom folosi o listă
-              neordonată.{' '}
+              neordonată.
+              {' '}
             </dd>
           </dl>
           <LessonTip icon={faThumbsUp}>
-            Iar pe final, nu uita că elementele <strong>{'<ul>'}</strong>,
-            <strong>{'<ol>'}</strong> și <strong>{'<dl>'}</strong> ajută atât în
+            Iar pe final, nu uita că elementele
+            {' '}
+            <strong>{'<ul>'}</strong>
+            ,
+            <strong>{'<ol>'}</strong>
+            {' '}
+            și
+            <strong>{'<dl>'}</strong>
+            {' '}
+            ajută atât în
             cazul screen-readere-lor cât și pe ceilalți developeri care vor
             înțelege mai ușor codul tău. Hai să le folosim când e vorba de
             liste.

--- a/client/curriculum/html/Lists.tsx
+++ b/client/curriculum/html/Lists.tsx
@@ -12,6 +12,7 @@ import Lesson, {
 import { Diana } from '~/services/contributors';
 import Highlight from '~/components/Highlight/Highlight';
 import coverSvg from '~/public/images/lessons/lists__cover.svg';
+import FormattedText from '~/components/FormattedText';
 
 const contributors = [Diana];
 const chapters = [
@@ -43,9 +44,10 @@ export default function ListsLesson() {
         <LessonContributors className="absolute" contributors={contributors} />
         <LessonCover>
           {/* eslint-disable-next-line react/no-danger */}
-          <div dangerouslySetInnerHTML={{
-            __html: coverSvg,
-          }}
+          <div
+            dangerouslySetInnerHTML={{
+              __html: coverSvg,
+            }}
           />
         </LessonCover>
         <p>
@@ -65,17 +67,14 @@ export default function ListsLesson() {
           <p>Există două tipuri de liste des folosite în HTML:</p>
           <ul className="with--bullets">
             <li className="mb-4">
-              <strong className="formatted">Liste neordonate</strong>
-              {' '}
-              -
+              <FormattedText as="strong">Liste neordonate</FormattedText> -
               utilizate pentru a grupa un set de elemente ce nu necesită o
               anumită ordine
             </li>
             <li>
-              <strong className="formatted">Liste ordonate</strong>
-              {' '}
-              - utilizate
-              pentru a grupa un set de elemente ce au o ordine specifică
+              <FormattedText as="strong">Liste ordonate</FormattedText> -
+              utilizate pentru a grupa un set de elemente ce au o ordine
+              specifică
             </li>
           </ul>
           <p>
@@ -111,29 +110,17 @@ export default function ListsLesson() {
           />
           <LessonTip>
             Observă cum ne folosim de 2 tipuri de elemente pentru a defini o
-            listă: în exterior avem
-            {' '}
-            <strong className="formatted">{'<ul>'}</strong>
-            {' '}
-            (unordered list)
-            pentru a defini lista, iar apoi fiecare element în propriul tag
-            {' '}
-            <strong className="formatted">{'<li>'}</strong>
-            {' '}
-            (list item) .
+            listă: în exterior avem{' '}
+            <FormattedText as="strong">{'<ul>'}</FormattedText> (unordered list)
+            pentru a defini lista, iar apoi fiecare element în propriul tag{' '}
+            <FormattedText as="strong">{'<li>'}</FormattedText> (list item) .
           </LessonTip>
           <p>
-            Cu o stilizare potrivită, listele neordonate sunt folosite la
-            {' '}
-            <strong>
-              realizarea meniurilor paginilor web
-            </strong>
-            .
-            {' '}
+            Cu o stilizare potrivită, listele neordonate sunt folosite la{' '}
+            <strong>realizarea meniurilor paginilor web</strong>.{' '}
             <a href="https://github.com" target="_blank" rel="noreferrer">
               GitHub
-            </a>
-            {' '}
+            </a>{' '}
             e un exemplu bun, ei folosind liste neordonate pentru meniul de
             navigare:
           </p>
@@ -175,12 +162,9 @@ export default function ListsLesson() {
           />
           <p>
             Acestea au o structura similară cu cele neordonate, singura
-            diferență fiind tag-ul:
-            {' '}
-            <strong className="formatted">{'<ol>'}</strong>
-            {' '}
-            (ordered list). E
-            evident că dacă vom schimba ordinea elementelor din cadrul listei,
+            diferență fiind tag-ul:{' '}
+            <FormattedText as="strong">{'<ol>'}</FormattedText> (ordered list).
+            E evident că dacă vom schimba ordinea elementelor din cadrul listei,
             aceasta nu va mai avea nici un sens.
           </p>
           <LessonFigure
@@ -196,41 +180,26 @@ export default function ListsLesson() {
           </LessonHeading>
           <p>
             Dacă vrem ca enumerarea elementelor din listă să se facă cu un
-            anumit tip de cifră sau cu litere, ne putem folosi de atributul
-            {' '}
-            <strong className="formatted"> type</strong>
-            . Acesta acceptă ca
+            anumit tip de cifră sau cu litere, ne putem folosi de atributul{' '}
+            <FormattedText as="strong"> type</FormattedText>. Acesta acceptă ca
             valori:
           </p>
           <ul className="with--bullets">
             <li className="mb-4">
               {' '}
-              <strong className="formatted">1</strong>
-              {' '}
-              – pentru enumerare cu
-              {' '}
+              <FormattedText as="strong">1</FormattedText> – pentru enumerare cu{' '}
               cifre arabe;
             </li>
             <li className="mb-4">
               {' '}
-              <strong className="formatted">i</strong>
-              {' '}
-              sau
-              {' '}
-              <strong className="formatted">I</strong>
-              {' '}
-              – pentru enumerare cu
+              <FormattedText as="strong">i</FormattedText> sau{' '}
+              <FormattedText as="strong">I</FormattedText> – pentru enumerare cu
               cifre romane mici, respectiv mari
             </li>
             <li className="mb-4">
               {' '}
-              <strong className="formatted">a</strong>
-              {' '}
-              sau
-              {' '}
-              <strong className="formatted">A</strong>
-              {' '}
-              – pentru enumerare cu
+              <FormattedText as="strong">a</FormattedText> sau{' '}
+              <FormattedText as="strong">A</FormattedText> – pentru enumerare cu
               litere mici, respectiv mari.
             </li>
           </ul>
@@ -253,11 +222,8 @@ export default function ListsLesson() {
           />
           <p>
             Dacă vrem ca lista să înceapă enumerarea de la cifra/litera cea mai
-            avansată și să se termine cu prima, vom folosi atributul
-            {' '}
-            <strong className="formatted">reversed</strong>
-            {' '}
-            .
+            avansată și să se termine cu prima, vom folosi atributul{' '}
+            <FormattedText as="strong">reversed</FormattedText> .
           </p>
           <LessonFigure
             withBorder
@@ -267,12 +233,9 @@ export default function ListsLesson() {
           />
           <p>
             Putem opta chiar să enumerăm elementele unei liste ordonate începând
-            de la un anumit număr/literă. Pentru asta ne vom folosi de atributul
-            {' '}
-            <strong className="formatted">start</strong>
-            {' '}
-            dând ca valoare numărul
-            sau litera de la care vrem sa începem numărătoarea:
+            de la un anumit număr/literă. Pentru asta ne vom folosi de atributul{' '}
+            <FormattedText as="strong">start</FormattedText> dând ca valoare
+            numărul sau litera de la care vrem sa începem numărătoarea:
           </p>
           <LessonFigure
             withBorder
@@ -314,11 +277,10 @@ export default function ListsLesson() {
             demo="/demo/html/sub-liste"
           />
           <p>
-            În exemplul de mai sus am inclus o listă ordonată în cadrul
-            unei liste neordonate, dar putem foarte bine să includem orice tip
-            de listă în oricare altul. Ce e important să reținem este că nivelul
-            de nesting să nu fie mai mare de 3 căci lucrurile pot deveni
-            confuze.
+            În exemplul de mai sus am inclus o listă ordonată în cadrul unei
+            liste neordonate, dar putem foarte bine să includem orice tip de
+            listă în oricare altul. Ce e important să reținem este că nivelul de
+            nesting să nu fie mai mare de 3 căci lucrurile pot deveni confuze.
           </p>
         </section>
         <section>
@@ -327,13 +289,10 @@ export default function ListsLesson() {
           </LessonHeading>
           <p>
             Există și un al treilea tip de listă pe care-l vei întâlni mai rar
-            dar e totuși bine să-l știi:
-            {' '}
-            <strong className="formatted">{'<dl>'}</strong>
-            {' '}
-            (description list).
-            Îl vom folosi când definim termeni sau asociem perechi de valori, ca
-            în exemplul de mai jos:
+            dar e totuși bine să-l știi:{' '}
+            <FormattedText as="strong">{'<dl>'}</FormattedText> (description
+            list). Îl vom folosi când definim termeni sau asociem perechi de
+            valori, ca în exemplul de mai jos:
           </p>
           <Highlight
             language="html"
@@ -366,8 +325,7 @@ export default function ListsLesson() {
             </dt>
             <dd className="mb-4">
               {' '}
-              Dacă da, vom folosi o listă de descrieri.
-              {' '}
+              Dacă da, vom folosi o listă de descrieri.{' '}
             </dd>
 
             <dt className="text-bold">
@@ -376,24 +334,15 @@ export default function ListsLesson() {
             <dd>
               {' '}
               Dacă da, folosim o listă ordonată, altfel vom folosi o listă
-              neordonată.
-              {' '}
+              neordonată.{' '}
             </dd>
           </dl>
           <LessonTip icon={faThumbsUp}>
-            Iar pe final, nu uita că elementele
-            {' '}
-            <strong>{'<ul>'}</strong>
-            ,
-            <strong>{'<ol>'}</strong>
-            {' '}
-            și
-            {' '}
-            <strong>{'<dl>'}</strong>
-            {' '}
-            ajută atât în cazul
-            screen-readere-lor cât și pe ceilalți developeri care vor înțelege
-            mai ușor codul tău. Hai să le folosim când e vorba de liste.
+            Iar pe final, nu uita că elementele <strong>{'<ul>'}</strong>,
+            <strong>{'<ol>'}</strong> și <strong>{'<dl>'}</strong> ajută atât în
+            cazul screen-readere-lor cât și pe ceilalți developeri care vor
+            înțelege mai ușor codul tău. Hai să le folosim când e vorba de
+            liste.
           </LessonTip>
         </section>
         <div className="dots" />

--- a/client/curriculum/html/TextElements.tsx
+++ b/client/curriculum/html/TextElements.tsx
@@ -37,6 +37,7 @@ export default function TextsLesson() {
         <LessonCover resizeOffset={150}>
           {/* eslint-disable-next-line react/no-danger */}
           <div
+            // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: coverSvg,
             }}
@@ -53,23 +54,40 @@ export default function TextsLesson() {
           </LessonHeading>
           <p>
             HTML oferă șase elemente pentru titluri (headings), care pot fi
-            marcate utilizînd tagurile:{' '}
-            <FormattedText as="strong">{'<h1>'}</FormattedText>,{' '}
-            <FormattedText as="strong">{'<h2>'}</FormattedText>,{' '}
-            <FormattedText as="strong">{'<h3>'}</FormattedText>,{' '}
-            <FormattedText as="strong">{'<h4>'}</FormattedText>,{' '}
-            <FormattedText as="strong">{'<h5>'}</FormattedText> și{' '}
-            <FormattedText as="strong">{'<h6>'}</FormattedText>.
+            marcate utilizînd tagurile:
+            {' '}
+            <FormattedText as="strong">{'<h1>'}</FormattedText>
+            ,
+            {' '}
+            <FormattedText as="strong">{'<h2>'}</FormattedText>
+            ,
+            {' '}
+            <FormattedText as="strong">{'<h3>'}</FormattedText>
+            ,
+            {' '}
+            <FormattedText as="strong">{'<h4>'}</FormattedText>
+            ,
+            {' '}
+            <FormattedText as="strong">{'<h5>'}</FormattedText>
+            {' '}
+            și
+            {' '}
+            <FormattedText as="strong">{'<h6>'}</FormattedText>
+            .
           </p>
           <p>
-            <FormattedText as="strong">{'<h1>'}</FormattedText> este folosit
+            <FormattedText as="strong">{'<h1>'}</FormattedText>
+            {' '}
+            este folosit
             pentru titlul principal al paginii, următoarele fiind utilizate
             pentru a marca subtitluri în ordinea importanței lor. Este
-            recomandat să avem{' '}
+            recomandat să avem
+            {' '}
             <strong>
               un singur
               {' <h1>'}
-            </strong>{' '}
+            </strong>
+            {' '}
             în pagină, pentru a arăta motoarelor de căutare care este subiectul
             principal al paginii.
           </p>
@@ -80,12 +98,20 @@ export default function TextsLesson() {
 <h1> Texte | Lecție HTML </h1>`}
           />
           <p>
-            În principiu <FormattedText as="strong">{'<h1>'}</FormattedText> va
-            avea fontul cel mai mare, iar{' '}
-            <FormattedText as="strong">{'<h6>'}</FormattedText> cel mai mic,
+            În principiu
+            {' '}
+            <FormattedText as="strong">{'<h1>'}</FormattedText>
+            {' '}
+            va
+            avea fontul cel mai mare, iar
+            {' '}
+            <FormattedText as="strong">{'<h6>'}</FormattedText>
+            {' '}
+            cel mai mic,
             deși aceasta nu este neapărat o regulă bătută în cuie. Fiecare
             browser vine cu propriile stiluri asupra elementelor de bază, însă
-            mai târziu vom vedea cum putem adăuga propriile stiluri via{' '}
+            mai târziu vom vedea cum putem adăuga propriile stiluri via
+            {' '}
             <Link href="/css/intro">
               <a>CSS</a>
             </Link>
@@ -103,9 +129,16 @@ export default function TextsLesson() {
           </p>
           <LessonTip>
             Să ne asiguram că atunci cînd folosim titluri, ținem cont de ordinea
-            lor in ierarhie. Adică, dacă am folosit un <strong>h3</strong> ce
-            reprezintă un subtitlu în pagină, nu vom folosi după acesta un{' '}
-            <strong>h2</strong> să reprezentăm un sub-subtitlu. Nu ar avea nici
+            lor in ierarhie. Adică, dacă am folosit un
+            {' '}
+            <strong>h3</strong>
+            {' '}
+            ce
+            reprezintă un subtitlu în pagină, nu vom folosi după acesta un
+            {' '}
+            <strong>h2</strong>
+            {' '}
+            să reprezentăm un sub-subtitlu. Nu ar avea nici
             un sens să facem asta, nu?
           </LessonTip>
           <LessonTip>
@@ -119,8 +152,10 @@ export default function TextsLesson() {
             Paragrafe
           </LessonHeading>
           <p>
-            Elementele de tip paragraf sunt marcate cu ajutorul tag-ului{' '}
-            <FormattedText as="strong">{'<p>'}</FormattedText>. Vom folosi acest
+            Elementele de tip paragraf sunt marcate cu ajutorul tag-ului
+            {' '}
+            <FormattedText as="strong">{'<p>'}</FormattedText>
+            . Vom folosi acest
             element pentru a insera paragrafe de text fără vreo proprietate sau
             înțeles special.
           </p>
@@ -131,10 +166,13 @@ export default function TextsLesson() {
 <p> Acesta este un paragraf cu câteva cuvinte. </p>`}
           />
           <p>
-            De fiecare dată când va întâlni tag-ul{' '}
-            <FormattedText as="strong">{'<p>'}</FormattedText>, browser-ul va
+            De fiecare dată când va întâlni tag-ul
+            {' '}
+            <FormattedText as="strong">{'<p>'}</FormattedText>
+            , browser-ul va
             afișa conținutul acestuia începînd cu o nouă linie (spunem că
-            paragrafele sunt elemente de tip{' '}
+            paragrafele sunt elemente de tip
+            {' '}
             <a
               target="_blank"
               rel="noreferrer"
@@ -153,11 +191,16 @@ export default function TextsLesson() {
           />
           <div className="dots" />
           <p>
-            Dacă ai experimentat cu codul până acum, poate ai observat că dând{' '}
-            <FormattedText as="strong">Enter</FormattedText> într-un paragraf,
+            Dacă ai experimentat cu codul până acum, poate ai observat că dând
+            {' '}
+            <FormattedText as="strong">Enter</FormattedText>
+            {' '}
+            într-un paragraf,
             nu va afișa textul pe o nouă linie. Ca să obținem asta putem fie să
-            folosim un nou paragraf, fie tag-ul{' '}
-            <FormattedText as="strong">{'<br>'}</FormattedText>.
+            folosim un nou paragraf, fie tag-ul
+            {' '}
+            <FormattedText as="strong">{'<br>'}</FormattedText>
+            .
           </p>
           <Highlight
             className="my-5"
@@ -183,7 +226,10 @@ export default function TextsLesson() {
             {'Elementul <hr>'}
           </LessonHeading>
           <p>
-            Elementul <FormattedText as="strong">{'<hr>'}</FormattedText>{' '}
+            Elementul
+            {' '}
+            <FormattedText as="strong">{'<hr>'}</FormattedText>
+            {' '}
             (horizontal line) este un separator între secțiuni/elemente din
             pagină.
           </p>
@@ -209,8 +255,10 @@ export default function TextsLesson() {
           </LessonHeading>
           <p>
             Atunci când vrem să marcăm un text mai lung preluat dintr-o anumită
-            sursă ne vom folosi de tag-ul{' '}
-            <FormattedText as="strong">{'<blockquote>'}</FormattedText>. Acest
+            sursă ne vom folosi de tag-ul
+            {' '}
+            <FormattedText as="strong">{'<blockquote>'}</FormattedText>
+            . Acest
             tag vine la pachet cu o indentare default.
           </p>
           <Highlight
@@ -225,7 +273,8 @@ export default function TextsLesson() {
             `}
           />
           <p>
-            Dacă avem nevoie să marcăm un citat mai scurt, vom folosi tag-ul{' '}
+            Dacă avem nevoie să marcăm un citat mai scurt, vom folosi tag-ul
+            {' '}
             <FormattedText as="strong">{'<q>'}</FormattedText>
             (quote).
           </p>
@@ -248,8 +297,11 @@ export default function TextsLesson() {
             demo="/demo/html/citate"
           />
           <LessonTip>
-            După cum poți observa mai sus, ambele elemente au atributul{' '}
-            <FormattedText as="strong">cite</FormattedText> pe care îl folosim
+            După cum poți observa mai sus, ambele elemente au atributul
+            {' '}
+            <FormattedText as="strong">cite</FormattedText>
+            {' '}
+            pe care îl folosim
             pentru a marca sursa citatului.
           </LessonTip>
         </section>
@@ -265,8 +317,11 @@ export default function TextsLesson() {
           <p>
             HTML oferă diverse elemente semantice pentru a ne permite să marcăm
             conținutul textual cu astfel de efecte. . Unul dintre aceste
-            elemente este tag-ul{' '}
-            <FormattedText as="strong">{'<em>'}</FormattedText> .
+            elemente este tag-ul
+            {' '}
+            <FormattedText as="strong">{'<em>'}</FormattedText>
+            {' '}
+            .
           </p>
           <Highlight
             className="my-5"
@@ -278,18 +333,26 @@ export default function TextsLesson() {
             `}
           />
           <p>
-            Mai avem la dispoziție și tag-ul{' '}
-            <FormattedText as="strong">{'<strong>'}</FormattedText> , folosit
+            Mai avem la dispoziție și tag-ul
+            {' '}
+            <FormattedText as="strong">{'<strong>'}</FormattedText>
+            {' '}
+            , folosit
             pentru a marca un element ca fiind foarte important. Fiind un
             element semantic, acesta este recunoscut de cititoarele de ecrane și
             redat cu o tonalitate diferită a vocii.
           </p>
           <p>
-            Deși browserele afișează acest element îngroșat (bolduit),{' '}
-            <strong>nu ar trebui să folosim</strong>{' '}
-            <FormattedText as="span">{'<strong>'}</FormattedText> doar pentru a
+            Deși browserele afișează acest element îngroșat (bolduit),
+            {' '}
+            <strong>nu ar trebui să folosim</strong>
+            {' '}
+            <FormattedText as="span">{'<strong>'}</FormattedText>
+            {' '}
+            doar pentru a
             obține acest rezultat. Pentru a face asta vom folosi un element de
-            tip <FormattedText as="span">{'<span>'}</FormattedText>
+            tip
+            <FormattedText as="span">{'<span>'}</FormattedText>
             pe care vom aplica stiluri CSS.
           </p>
         </section>

--- a/client/curriculum/html/TextElements.tsx
+++ b/client/curriculum/html/TextElements.tsx
@@ -11,6 +11,7 @@ import Lesson, {
 import { Diana } from '~/services/contributors';
 import Highlight from '~/components/Highlight/Highlight';
 import coverSvg from '~/public/images/lessons/text-elements__cover.svg';
+import FormattedText from '~/components/FormattedText';
 
 const contributors = [Diana];
 const chapters = [
@@ -35,14 +36,15 @@ export default function TextsLesson() {
         <LessonContributors className="absolute" contributors={contributors} />
         <LessonCover resizeOffset={150}>
           {/* eslint-disable-next-line react/no-danger */}
-          <div dangerouslySetInnerHTML={{
-            __html: coverSvg,
-          }}
+          <div
+            dangerouslySetInnerHTML={{
+              __html: coverSvg,
+            }}
           />
         </LessonCover>
         <p>
-          Acest articol explică modul în care HTML poate fi utilizat pentru a structura o
-          pagină de text prin adăugarea de titluri și paragrafe,
+          Acest articol explică modul în care HTML poate fi utilizat pentru a
+          structura o pagină de text prin adăugarea de titluri și paragrafe,
           accentuarea cuvintelor și multe altele.
         </p>
         <section>
@@ -50,44 +52,26 @@ export default function TextsLesson() {
             Titluri (Headings)
           </LessonHeading>
           <p>
-            HTML oferă șase elemente pentru titluri (headings), care pot fi marcate
-            utilizînd tagurile:
-            {' '}
-            <strong className="formatted">{'<h1>'}</strong>
-            ,
-            {' '}
-            <strong className="formatted">{'<h2>'}</strong>
-            ,
-            {' '}
-            <strong className="formatted">{'<h3>'}</strong>
-            ,
-            {' '}
-            <strong className="formatted">{'<h4>'}</strong>
-            ,
-            {' '}
-            <strong className="formatted">{'<h5>'}</strong>
-            {' '}
-            și
-            {' '}
-            <strong className="formatted">{'<h6>'}</strong>
-            .
+            HTML oferă șase elemente pentru titluri (headings), care pot fi
+            marcate utilizînd tagurile:{' '}
+            <FormattedText as="strong">{'<h1>'}</FormattedText>,{' '}
+            <FormattedText as="strong">{'<h2>'}</FormattedText>,{' '}
+            <FormattedText as="strong">{'<h3>'}</FormattedText>,{' '}
+            <FormattedText as="strong">{'<h4>'}</FormattedText>,{' '}
+            <FormattedText as="strong">{'<h5>'}</FormattedText> și{' '}
+            <FormattedText as="strong">{'<h6>'}</FormattedText>.
           </p>
           <p>
-            <strong className="formatted">
-              {'<h1>'}
-            </strong>
-            {' '}
-            este folosit pentru titlul principal al
-            paginii, următoarele fiind utilizate pentru a marca subtitluri în
-            ordinea importanței lor. Este recomandat să avem
-            {' '}
+            <FormattedText as="strong">{'<h1>'}</FormattedText> este folosit
+            pentru titlul principal al paginii, următoarele fiind utilizate
+            pentru a marca subtitluri în ordinea importanței lor. Este
+            recomandat să avem{' '}
             <strong>
               un singur
               {' <h1>'}
-            </strong>
-            {' '}
-            în pagină, pentru a arăta motoarelor de
-            căutare care este subiectul principal al paginii.
+            </strong>{' '}
+            în pagină, pentru a arăta motoarelor de căutare care este subiectul
+            principal al paginii.
           </p>
           <Highlight
             className="my-5"
@@ -96,26 +80,14 @@ export default function TextsLesson() {
 <h1> Texte | Lecție HTML </h1>`}
           />
           <p>
-            În principiu
-            {' '}
-            <strong className="formatted">{'<h1>'}</strong>
-            {' '}
-            va avea fontul cel mai mare, iar
-            {' '}
-            <strong className="formatted">
-              {'<h6>'}
-            </strong>
-            {' '}
-            cel mai mic,
-            deși aceasta nu este neapărat o regulă bătută în cuie.
-
-            Fiecare browser vine cu propriile stiluri asupra elementelor de bază,
-            însă mai târziu vom vedea cum putem adăuga propriile stiluri via
-            {' '}
+            În principiu <FormattedText as="strong">{'<h1>'}</FormattedText> va
+            avea fontul cel mai mare, iar{' '}
+            <FormattedText as="strong">{'<h6>'}</FormattedText> cel mai mic,
+            deși aceasta nu este neapărat o regulă bătută în cuie. Fiecare
+            browser vine cu propriile stiluri asupra elementelor de bază, însă
+            mai târziu vom vedea cum putem adăuga propriile stiluri via{' '}
             <Link href="/css/intro">
-              <a>
-                CSS
-              </a>
+              <a>CSS</a>
             </Link>
             .
           </p>
@@ -131,16 +103,9 @@ export default function TextsLesson() {
           </p>
           <LessonTip>
             Să ne asiguram că atunci cînd folosim titluri, ținem cont de ordinea
-            lor in ierarhie. Adică, dacă am folosit un
-            {' '}
-            <strong>h3</strong>
-            {' '}
-            ce
-            reprezintă un subtitlu în pagină, nu vom folosi după acesta un
-            {' '}
-            <strong>h2</strong>
-            {' '}
-            să reprezentăm un sub-subtitlu. Nu ar avea nici
+            lor in ierarhie. Adică, dacă am folosit un <strong>h3</strong> ce
+            reprezintă un subtitlu în pagină, nu vom folosi după acesta un{' '}
+            <strong>h2</strong> să reprezentăm un sub-subtitlu. Nu ar avea nici
             un sens să facem asta, nu?
           </LessonTip>
           <LessonTip>
@@ -154,11 +119,10 @@ export default function TextsLesson() {
             Paragrafe
           </LessonHeading>
           <p>
-            Elementele de tip paragraf sunt marcate cu ajutorul tag-ului
-            {' '}
-            <strong className="formatted">{'<p>'}</strong>
-            . Vom folosi acest element pentru a insera paragrafe de text fără
-            vreo proprietate sau înțeles special.
+            Elementele de tip paragraf sunt marcate cu ajutorul tag-ului{' '}
+            <FormattedText as="strong">{'<p>'}</FormattedText>. Vom folosi acest
+            element pentru a insera paragrafe de text fără vreo proprietate sau
+            înțeles special.
           </p>
           <Highlight
             className="my-5"
@@ -167,17 +131,19 @@ export default function TextsLesson() {
 <p> Acesta este un paragraf cu câteva cuvinte. </p>`}
           />
           <p>
-            De fiecare dată când va întâlni tag-ul
-            {' '}
-            <strong className="formatted">{'<p>'}</strong>
-            , browser-ul va afișa
-            conținutul acestuia începînd cu o nouă linie (spunem că paragrafele
-            sunt elemente de tip
-            {' '}
-            <a target="_blank" rel="noreferrer" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements">
+            De fiecare dată când va întâlni tag-ul{' '}
+            <FormattedText as="strong">{'<p>'}</FormattedText>, browser-ul va
+            afișa conținutul acestuia începînd cu o nouă linie (spunem că
+            paragrafele sunt elemente de tip{' '}
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href="https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements"
+            >
               block
             </a>
-            ). Același lucru se întâmplă și cu titlurile, după cum poți vedea în demo-ul de mai jos.
+            ). Același lucru se întâmplă și cu titlurile, după cum poți vedea în
+            demo-ul de mai jos.
           </p>
           <LessonFigure
             withBorder
@@ -187,18 +153,11 @@ export default function TextsLesson() {
           />
           <div className="dots" />
           <p>
-            Dacă ai experimentat cu codul până acum, poate ai observat că dând
-            {' '}
-            <strong className="formatted">Enter</strong>
-            {' '}
-            într-un paragraf, nu va afișa textul pe o nouă linie.
-            Ca să obținem asta putem fie să folosim un nou paragraf, fie
-            tag-ul
-            {' '}
-            <strong className="formatted">
-              {'<br>'}
-            </strong>
-            .
+            Dacă ai experimentat cu codul până acum, poate ai observat că dând{' '}
+            <FormattedText as="strong">Enter</FormattedText> într-un paragraf,
+            nu va afișa textul pe o nouă linie. Ca să obținem asta putem fie să
+            folosim un nou paragraf, fie tag-ul{' '}
+            <FormattedText as="strong">{'<br>'}</FormattedText>.
           </p>
           <Highlight
             className="my-5"
@@ -224,15 +183,9 @@ export default function TextsLesson() {
             {'Elementul <hr>'}
           </LessonHeading>
           <p>
-            Elementul
-            {' '}
-            <strong className="formatted">
-              {'<hr>'}
-            </strong>
-            {' '}
-            (horizontal line)
-            este un separator între
-            secțiuni/elemente din pagină.
+            Elementul <FormattedText as="strong">{'<hr>'}</FormattedText>{' '}
+            (horizontal line) este un separator între secțiuni/elemente din
+            pagină.
           </p>
           <Highlight
             className="my-5"
@@ -256,11 +209,9 @@ export default function TextsLesson() {
           </LessonHeading>
           <p>
             Atunci când vrem să marcăm un text mai lung preluat dintr-o anumită
-            sursă ne vom folosi de tag-ul
-            {' '}
-            <strong className="formatted">{'<blockquote>'}</strong>
-            .
-            Acest tag vine la pachet cu o indentare default.
+            sursă ne vom folosi de tag-ul{' '}
+            <FormattedText as="strong">{'<blockquote>'}</FormattedText>. Acest
+            tag vine la pachet cu o indentare default.
           </p>
           <Highlight
             className="my-5"
@@ -274,9 +225,8 @@ export default function TextsLesson() {
             `}
           />
           <p>
-            Dacă avem nevoie să marcăm un citat mai scurt, vom folosi tag-ul
-            {' '}
-            <strong className="formatted">{'<q>'}</strong>
+            Dacă avem nevoie să marcăm un citat mai scurt, vom folosi tag-ul{' '}
+            <FormattedText as="strong">{'<q>'}</FormattedText>
             (quote).
           </p>
           <Highlight
@@ -298,11 +248,9 @@ export default function TextsLesson() {
             demo="/demo/html/citate"
           />
           <LessonTip>
-            După cum poți observa mai sus, ambele elemente au atributul
-            {' '}
-            <strong className="formatted">cite</strong>
-            {' '}
-            pe care îl folosim pentru a marca sursa citatului.
+            După cum poți observa mai sus, ambele elemente au atributul{' '}
+            <FormattedText as="strong">cite</FormattedText> pe care îl folosim
+            pentru a marca sursa citatului.
           </LessonTip>
         </section>
         <section>
@@ -315,17 +263,10 @@ export default function TextsLesson() {
             importante sau diferite într-un fel.
           </p>
           <p>
-            HTML oferă diverse elemente
-            semantice pentru a ne permite să marcăm conținutul textual cu astfel
-            de efecte.
-            .
-            Unul dintre aceste elemente este tag-ul
-            {' '}
-            <strong className="formatted">
-              {'<em>'}
-            </strong>
-            {' '}
-            .
+            HTML oferă diverse elemente semantice pentru a ne permite să marcăm
+            conținutul textual cu astfel de efecte. . Unul dintre aceste
+            elemente este tag-ul{' '}
+            <FormattedText as="strong">{'<em>'}</FormattedText> .
           </p>
           <Highlight
             className="my-5"
@@ -337,32 +278,18 @@ export default function TextsLesson() {
             `}
           />
           <p>
-            Mai avem la dispoziție și tag-ul
-            {' '}
-            <strong className="formatted">
-              {'<strong>'}
-            </strong>
-            {' '}
-            , folosit pentru a marca un element ca fiind
-            foarte important. Fiind un element semantic, acesta este recunoscut
-            de cititoarele de ecrane și redat cu o tonalitate diferită a vocii.
+            Mai avem la dispoziție și tag-ul{' '}
+            <FormattedText as="strong">{'<strong>'}</FormattedText> , folosit
+            pentru a marca un element ca fiind foarte important. Fiind un
+            element semantic, acesta este recunoscut de cititoarele de ecrane și
+            redat cu o tonalitate diferită a vocii.
           </p>
           <p>
-            Deși browserele afișează acest element îngroșat (bolduit),
-            {' '}
-            <strong>nu ar trebui să folosim</strong>
-            {' '}
-            <span className="formatted">
-              {'<strong>'}
-            </span>
-            {' '}
-            doar pentru a obține acest rezultat. Pentru a face asta
-            vom folosi un element de tip
-            {' '}
-            <span className="formatted">
-              {'<span>'}
-            </span>
-            {' '}
+            Deși browserele afișează acest element îngroșat (bolduit),{' '}
+            <strong>nu ar trebui să folosim</strong>{' '}
+            <FormattedText as="span">{'<strong>'}</FormattedText> doar pentru a
+            obține acest rezultat. Pentru a face asta vom folosi un element de
+            tip <FormattedText as="span">{'<span>'}</FormattedText>
             pe care vom aplica stiluri CSS.
           </p>
         </section>

--- a/client/curriculum/intro/despre-noi.tsx
+++ b/client/curriculum/intro/despre-noi.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import SEOTags from '~/components/SEOTags';
@@ -69,8 +70,11 @@ export default function Lesson0() {
           <p>
             Comunitatea gravitează în jurul unei serii de lecții și exerciții
             gratuite ce constituie - în opinia noastră - fundamentele unei
-            cariere moderne în FrontEnd Development. Deși abia la{' '}
-            <span className="line-through">prima</span> a doua iterație, acestea
+            cariere moderne în FrontEnd Development. Deși abia la
+            {' '}
+            <span className="line-through">prima</span>
+            {' '}
+            a doua iterație, acestea
             vor fi re-scrise, re-re-scrise și re-re-re-scrise în funcție de
             feedback-ul vostru până când vor ajunge una din cele mai calitative
             resurse de acest fel din România.
@@ -96,8 +100,10 @@ export default function Lesson0() {
             De ce e FrontEnd.ro gratuit?
           </LessonHeading>
           <p>
-            De la început ne-am dorit ca FrontEnd.ro să fie un{' '}
-            <strong>efort de comunitate, pentru comunitate</strong>. Lecțiile,
+            De la început ne-am dorit ca FrontEnd.ro să fie un
+            {' '}
+            <strong>efort de comunitate, pentru comunitate</strong>
+            . Lecțiile,
             exercițiile, acest site cât și feedback-ul pe care voi îl veți primi
             reprezintă o contribuție voluntară a unor developeri cu inimă mare
             din România.
@@ -113,7 +119,11 @@ export default function Lesson0() {
             Cum pot să ajut?
           </LessonHeading>
           <p>
-            Dacă folosești platforma să <strong>înveți FrontEnd</strong> și
+            Dacă folosești platforma să
+            {' '}
+            <strong>înveți FrontEnd</strong>
+            {' '}
+            și
             simți că te-a ajutat, atunci s-ar putea să fie de folos și
             prietenilor tăi. Am aprecia mult un share, așa putem avea un impact
             cât mai mare:
@@ -135,9 +145,13 @@ export default function Lesson0() {
             de mentor și să oferi înapoi comunității. 😄
           </p>
           <p>
-            Dacă <strong>ești FrontEnd Developer</strong>, atunci ne poți ajuta
+            Dacă
+            {' '}
+            <strong>ești FrontEnd Developer</strong>
+            , atunci ne poți ajuta
             prin oferirea de feedback cursanților, crearea de exerciții și
-            lecții sau dezvoltarea acestei platforme al cărei cod este{' '}
+            lecții sau dezvoltarea acestei platforme al cărei cod este
+            {' '}
             <a target="_blank" rel="noreferrer" href={GITHUB_URL}>
               open-source pe GitHub
             </a>
@@ -148,7 +162,8 @@ export default function Lesson0() {
                 . */}
           </p>
           <p>
-            Iar dacă{' '}
+            Iar dacă
+            {' '}
             <strong>
               ești o firmă tech și-ți place ce încercăm să facem aici
             </strong>
@@ -180,9 +195,16 @@ export default function Lesson0() {
             Totuși, fundamentele FrontEnd-ului nu se schimbă, și le vei folosi
             fie că construiești un site de prezentare, un magazin online sau
             următorul Instagram. De aceea, aici ne vom ocupa de fundamentele
-            celor 3 limbaje de programare ce compun FrontEnd-ul:{' '}
-            <strong>HTML</strong>, <strong>CSS</strong> și{' '}
-            <strong>JavaScript</strong>. Deocamdată avem lecții și exerciții
+            celor 3 limbaje de programare ce compun FrontEnd-ul:
+            {' '}
+            <strong>HTML</strong>
+            ,
+            <strong>CSS</strong>
+            {' '}
+            și
+            {' '}
+            <strong>JavaScript</strong>
+            . Deocamdată avem lecții și exerciții
             doar pentru primul, cel de HTML, însa după o rundă de feedback de la
             comunitate vom continua și cu celelalte două.
           </p>
@@ -195,10 +217,15 @@ export default function Lesson0() {
           <p>
             Focusul nostru este pe exerciții și feedback, acolo investim cel mai
             mult timp. Există deja o mulțime de articole și tutoriale extrem de
-            bune pe internet, așa că am decis ca lecțiile să reprezinte doar un{' '}
-            <strong>scurt rezumat</strong>, care la final va avea{' '}
-            <strong>link-uri către resurse mai detaliate</strong>. Din această
-            cauză, principala responsabilitate la partea de învățare este a ta.{' '}
+            bune pe internet, așa că am decis ca lecțiile să reprezinte doar un
+            {' '}
+            <strong>scurt rezumat</strong>
+            , care la final va avea
+            {' '}
+            <strong>link-uri către resurse mai detaliate</strong>
+            . Din această
+            cauză, principala responsabilitate la partea de învățare este a ta.
+            {' '}
           </p>
           <blockquote>
             Ne așteptăm să fii motivat și autodidact, să poți înțelege în mare
@@ -208,24 +235,29 @@ export default function Lesson0() {
             Pentru a învăța cât mai mult, începe cu lecția 0 (cea pe care o
             citești acum) și continuă pe rând cu fiecare lecție nouă. Citește
             rezumatul nostru, iar apoi aruncă un ochi pe resursele suplimentare,
-            înainte să te apuci de exerciții.{' '}
+            înainte să te apuci de exerciții.
+            {' '}
           </p>
           <p>
             <strong>
               Este foarte important să rezolvi toate exercițiile de la fiecare
               lecție.
-            </strong>{' '}
+            </strong>
+            {' '}
             Ai răbdare și încredere în noi, nu am încărcat site-ul cu exerciții
             inutile.
           </p>
           <p>
-            Apoi, după ce ne trimiți soluția ta vom ajunge la{' '}
-            <strong>partea de feedback</strong>. Fiind începător probabil vor fi
+            Apoi, după ce ne trimiți soluția ta vom ajunge la
+            {' '}
+            <strong>partea de feedback</strong>
+            . Fiind începător probabil vor fi
             undeva la 3-4-5 runde, în care-ți vom explica de ce anumite lucruri
             nu sunt bune și te vom ruga să le schimbi.
           </p>
           <p>
-            E extrem de important să{' '}
+            E extrem de important să
+            {' '}
             <strong>
               ai răbdare cu acest proces, și să nu fii prea dur cu tine
             </strong>
@@ -244,8 +276,14 @@ export default function Lesson0() {
           <p>
             Unul dintre cele mai faine lucruri la FrontEnd development este
             faptul că nu avem nevoie de prea multe lucruri înainte să începem.
-            În primul rând, un <strong>calculator</strong> și o{' '}
-            <strong>conexiune la internet</strong>.
+            În primul rând, un
+            {' '}
+            <strong>calculator</strong>
+            {' '}
+            și o
+            {' '}
+            <strong>conexiune la internet</strong>
+            .
           </p>
           <p> Apoi, specific pentru acest domeniu ai nevoie de:</p>
           <ol className="with--count">
@@ -253,7 +291,8 @@ export default function Lesson0() {
               <strong>un browser modern și cross-platform </strong>
               (ce poate fi instalat pe Windows, MacOS și Linux).
               <p>
-                Noi recomandăm unul dintre{' '}
+                Noi recomandăm unul dintre
+                {' '}
                 <a
                   target="_blank"
                   rel="noreferrer"
@@ -261,7 +300,8 @@ export default function Lesson0() {
                 >
                   Google Chrome
                 </a>
-                ,{' '}
+                ,
+                {' '}
                 <a
                   target="_blank"
                   rel="noreferrer"
@@ -270,7 +310,8 @@ export default function Lesson0() {
                   Mozilla Firefox
                 </a>
                 {'  '}
-                sau{' '}
+                sau
+                {' '}
                 <a
                   target="_blank"
                   rel="noreferrer"
@@ -295,10 +336,15 @@ export default function Lesson0() {
                 {' '}
                 Acest editor este extrem de popular printre developeri, așa că
                 hai să-l folosim chiar de la început pentru a ne familiariza cu
-                el. De asemenea, înainte să începi{' '}
-                <a href="/html/despre-html">Lecția 1</a> te invităm să arunci un
-                ochi pe acest{' '}
-                <a href="/intro/vs-code">mini-tutorial despre VSCode</a>.
+                el. De asemenea, înainte să începi
+                {' '}
+                <a href="/html/despre-html">Lecția 1</a>
+                {' '}
+                te invităm să arunci un
+                ochi pe acest
+                {' '}
+                <a href="/intro/vs-code">mini-tutorial despre VSCode</a>
+                .
               </p>
             </li>
           </ol>
@@ -323,7 +369,8 @@ export default function Lesson0() {
                 className="text-bold"
               >
                 MDN - Mozilla Developer Network
-              </a>{' '}
+              </a>
+              {' '}
               este locul unde găsim cele mai calitative și detaliate
               documentații despre HTML, CSS și JavaScript - cele 3 limbaje ce
               compun FrontEnd development-ul.
@@ -335,9 +382,11 @@ export default function Lesson0() {
               </p>
               <p>
                 De exemplu, poate am uitat cum schimbăm culoarea de fundal a
-                unui element din pagină, caz în care vom căuta{' '}
+                unui element din pagină, caz în care vom căuta
+                {' '}
                 {/* <span className="formatted">background color MDN</span> */}
-                <FormattedText as="span">background color MDN</FormattedText>.
+                <FormattedText as="span">background color MDN</FormattedText>
+                .
                 Recomandăm să pui “MDN” la final pentru ca pagina căutată să
                 apară printre primele rezultate.
               </p>
@@ -364,7 +413,8 @@ export default function Lesson0() {
                 className="text-bold"
               >
                 Stack Overflow
-              </a>{' '}
+              </a>
+              {' '}
               este o comunitate de developeri ce învață și codează împreună.
               <p>
                 Mai exact, este cea mai populară platformă de întrebări și
@@ -376,7 +426,8 @@ export default function Lesson0() {
               <p>
                 {' '}
                 Iar dacă ești curios, poți arunca un ochi pe ultimele întrebări
-                adăugate pentru limbajele ce le vom învăța aici:{' '}
+                adăugate pentru limbajele ce le vom învăța aici:
+                {' '}
                 <a
                   target="_blank"
                   rel="noreferrer"
@@ -384,15 +435,18 @@ export default function Lesson0() {
                 >
                   HTML
                 </a>
-                ,{' '}
+                ,
+                {' '}
                 <a
                   target="_blank"
                   rel="noreferrer"
                   href="https://stackoverflow.com/questions/tagged/css"
                 >
                   CSS
-                </a>{' '}
-                si{' '}
+                </a>
+                {' '}
+                si
+                {' '}
                 <a
                   target="_blank"
                   rel="noreferrer"

--- a/client/curriculum/intro/despre-noi.tsx
+++ b/client/curriculum/intro/despre-noi.tsx
@@ -3,12 +3,16 @@ import { useRouter } from 'next/router';
 import SEOTags from '~/components/SEOTags';
 import Lesson from '~/components/lessons/Lesson';
 import {
-  LessonCover, LessonContributors, LessonHeading, LessonFigure,
+  LessonCover,
+  LessonContributors,
+  LessonHeading,
+  LessonFigure,
 } from '~/components/lessons';
 import { ShareButton } from '~/components/SocialMediaButtons';
 import { Ira, Pava } from '~/services/contributors';
 import { GITHUB_URL } from '~/services/Constants';
 import coverSvg from '~/public/images/lessons/lesson-0__cover.svg';
+import FormattedText from '~/components/FormattedText';
 
 const contributors = [Pava, Ira];
 
@@ -39,50 +43,52 @@ export default function Lesson0() {
         description="Detalii despre noi, despre platformă și cum vom lucra împreună."
         url="https://FrontEnd.ro/intro/despre-noi"
       />
-      <Lesson id="despre-noi" title="Introducere" chapters={chapters} withExercises={false}>
+      <Lesson
+        id="despre-noi"
+        title="Introducere"
+        chapters={chapters}
+        withExercises={false}
+      >
         <LessonContributors className="absolute" contributors={contributors} />
         <LessonCover resizeOffset={100}>
           {/* eslint-disable-next-line react/no-danger */}
-          <div dangerouslySetInnerHTML={{
-            __html: coverSvg,
-          }}
+          <div
+            dangerouslySetInnerHTML={{
+              __html: coverSvg,
+            }}
           />
-
         </LessonCover>
         <section>
           <LessonHeading as="h2" id="introducere">
             Ce e FrontEnd.ro?
           </LessonHeading>
           <p>
-            FrontEnd.ro este o comunitate de oameni ce învață FrontEnd de la zero.
+            FrontEnd.ro este o comunitate de oameni ce învață FrontEnd de la
+            zero.
           </p>
           <p>
             Comunitatea gravitează în jurul unei serii de lecții și exerciții
-            gratuite ce constituie - în opinia noastră - fundamentele unei cariere moderne
-            în FrontEnd Development. Deși abia la
-            {' '}
-            <span className="line-through">prima</span>
-            {' '}
-            a doua iterație, acestea vor fi
-            re-scrise, re-re-scrise și re-re-re-scrise în funcție de feedback-ul vostru
-            până când vor ajunge una din cele mai calitative resurse de acest fel din România.
+            gratuite ce constituie - în opinia noastră - fundamentele unei
+            cariere moderne în FrontEnd Development. Deși abia la{' '}
+            <span className="line-through">prima</span> a doua iterație, acestea
+            vor fi re-scrise, re-re-scrise și re-re-re-scrise în funcție de
+            feedback-ul vostru până când vor ajunge una din cele mai calitative
+            resurse de acest fel din România.
           </p>
         </section>
         <section>
           <LessonHeading as="h2" id="de-ce-suntem-diferiti">
             De ce e FrontEnd.ro diferit?
           </LessonHeading>
-          <p>
-            Noi suntem convinși că:
-          </p>
+          <p>Noi suntem convinși că:</p>
           <blockquote className="is--center">
             Nu contează la câte tutoriale te uiți, ci cât de mult codezi
           </blockquote>
           <p>
-            Însă când înveți singur e puțin mai greu să-ți dai seama dacă rezolvarea
-            găsită de tine este cea mai bună. Așa că ne vei trimite aici rezolvările
-            la exerciții, iar noi - developeri cu experiență din comunitate -  îți
-            vom da feedback pentru fiecare.
+            Însă când înveți singur e puțin mai greu să-ți dai seama dacă
+            rezolvarea găsită de tine este cea mai bună. Așa că ne vei trimite
+            aici rezolvările la exerciții, iar noi - developeri cu experiență
+            din comunitate - îți vom da feedback pentru fiecare.
           </p>
         </section>
         <section>
@@ -90,20 +96,16 @@ export default function Lesson0() {
             De ce e FrontEnd.ro gratuit?
           </LessonHeading>
           <p>
-            De la început ne-am dorit ca FrontEnd.ro să fie un
-            {' '}
-            <strong>
-              efort de comunitate,
-              pentru comunitate
-            </strong>
-            . Lecțiile, exercițiile, acest site cât și feedback-ul
-            pe care voi îl veți primi reprezintă o contribuție voluntară a unor
-            developeri cu inimă mare din România.
+            De la început ne-am dorit ca FrontEnd.ro să fie un{' '}
+            <strong>efort de comunitate, pentru comunitate</strong>. Lecțiile,
+            exercițiile, acest site cât și feedback-ul pe care voi îl veți primi
+            reprezintă o contribuție voluntară a unor developeri cu inimă mare
+            din România.
           </p>
           <p>
-            Vrem să oferim șansa la cât
-            mai mulți oameni să învețe și să lucreze în acest domeniu, unul din cele mai
-            faine din lume, de aceea nu vom pune un preț pe această experiență.
+            Vrem să oferim șansa la cât mai mulți oameni să învețe și să lucreze
+            în acest domeniu, unul din cele mai faine din lume, de aceea nu vom
+            pune un preț pe această experiență.
           </p>
         </section>
         <section>
@@ -111,12 +113,10 @@ export default function Lesson0() {
             Cum pot să ajut?
           </LessonHeading>
           <p>
-            Dacă folosești platforma să
-            {' '}
-            <strong>înveți FrontEnd</strong>
-            {' '}
-            și simți că te-a ajutat, atunci s-ar putea să fie de folos și prietenilor
-            tăi. Am aprecia mult un share, așa putem avea un impact cât mai mare:
+            Dacă folosești platforma să <strong>înveți FrontEnd</strong> și
+            simți că te-a ajutat, atunci s-ar putea să fie de folos și
+            prietenilor tăi. Am aprecia mult un share, așa putem avea un impact
+            cât mai mare:
           </p>
           <div className="d-flex justify-content-center my-5">
             <ShareButton
@@ -130,19 +130,17 @@ export default function Lesson0() {
             />
           </div>
           <p>
-            Iar după ce avansezi în skill-uri și capeți mai multă experiență, chiar ne-am bucura
-            dacă vei reveni aici, de data aceasta din postura de mentor și să oferi
-            înapoi comunității. 😄
+            Iar după ce avansezi în skill-uri și capeți mai multă experiență,
+            chiar ne-am bucura dacă vei reveni aici, de data aceasta din postura
+            de mentor și să oferi înapoi comunității. 😄
           </p>
           <p>
-            Dacă
-            {' '}
-            <strong>ești FrontEnd Developer</strong>
-            , atunci ne poți ajuta prin oferirea de
-            feedback cursanților, crearea de exerciții și lecții sau dezvoltarea
-            acestei platforme al cărei cod este
-            {' '}
-            <a target="_blank" rel="noreferrer" href={GITHUB_URL}>open-source pe GitHub</a>
+            Dacă <strong>ești FrontEnd Developer</strong>, atunci ne poți ajuta
+            prin oferirea de feedback cursanților, crearea de exerciții și
+            lecții sau dezvoltarea acestei platforme al cărei cod este{' '}
+            <a target="_blank" rel="noreferrer" href={GITHUB_URL}>
+              open-source pe GitHub
+            </a>
             .
             {/* Mai mult despre acest proces gasesti in capitolul
                 {' '}
@@ -150,12 +148,12 @@ export default function Lesson0() {
                 . */}
           </p>
           <p>
-            Iar dacă
-            {' '}
-            <strong>ești o firmă tech și-ți place ce încercăm să facem aici</strong>
-            ,
-            poate găsim un mod să colaborăm și să ne ajutăm reciproc și comunitatea
-            în același timp.
+            Iar dacă{' '}
+            <strong>
+              ești o firmă tech și-ți place ce încercăm să facem aici
+            </strong>
+            , poate găsim un mod să colaborăm și să ne ajutăm reciproc și
+            comunitatea în același timp.
             {/*
             Aruncă un ochi
             {' '}
@@ -171,30 +169,21 @@ export default function Lesson0() {
             Skill-uri și concepte
           </LessonHeading>
           <p>
-            FrontEnd-ul, de fapt programarea în general, este un domeniu în continuă
-            dezvoltare și schimbare.
-            În fiecare lună apar lucruri noi, iar în cațiva ani tool-urile pe care
-            noi le folosim pot fi complet diferite. Ceea ce face
-            lucrurile extrem de interesante, dar și puțin complicate
-            când vrei să înveți acest domeniu...
+            FrontEnd-ul, de fapt programarea în general, este un domeniu în
+            continuă dezvoltare și schimbare. În fiecare lună apar lucruri noi,
+            iar în cațiva ani tool-urile pe care noi le folosim pot fi complet
+            diferite. Ceea ce face lucrurile extrem de interesante, dar și puțin
+            complicate când vrei să înveți acest domeniu...
           </p>
 
           <p>
-            Totuși, fundamentele FrontEnd-ului nu se schimbă, și le vei folosi fie că
-            construiești un site de prezentare, un magazin online sau următorul
-            Instagram. De aceea, aici ne vom ocupa de fundamentele celor
-            3 limbaje de programare ce compun FrontEnd-ul:
-            {' '}
-            <strong>HTML</strong>
-            ,
-            {' '}
-            <strong>CSS</strong>
-            {' '}
-            și
-            {' '}
-            <strong>JavaScript</strong>
-            . Deocamdată avem lecții și exerciții doar pentru
-            primul, cel de HTML, însa după o rundă de feedback de la
+            Totuși, fundamentele FrontEnd-ului nu se schimbă, și le vei folosi
+            fie că construiești un site de prezentare, un magazin online sau
+            următorul Instagram. De aceea, aici ne vom ocupa de fundamentele
+            celor 3 limbaje de programare ce compun FrontEnd-ul:{' '}
+            <strong>HTML</strong>, <strong>CSS</strong> și{' '}
+            <strong>JavaScript</strong>. Deocamdată avem lecții și exerciții
+            doar pentru primul, cel de HTML, însa după o rundă de feedback de la
             comunitate vom continua și cu celelalte două.
           </p>
         </section>
@@ -204,64 +193,48 @@ export default function Lesson0() {
             Cum să folosești platforma
           </LessonHeading>
           <p>
-            Focusul nostru este pe exerciții și feedback, acolo investim cel
-            mai mult timp. Există deja o mulțime de articole și tutoriale
-            extrem de bune pe internet, așa că am decis ca lecțiile să reprezinte
-            doar un
-            {' '}
-            <strong>scurt rezumat</strong>
-            ,  care la final va avea
-            {' '}
-            <strong>
-              link-uri către resurse
-              mai detaliate
-            </strong>
-            . Din această cauză, principala responsabilitate
-            la partea de învățare este a ta.
-            {' '}
+            Focusul nostru este pe exerciții și feedback, acolo investim cel mai
+            mult timp. Există deja o mulțime de articole și tutoriale extrem de
+            bune pe internet, așa că am decis ca lecțiile să reprezinte doar un{' '}
+            <strong>scurt rezumat</strong>, care la final va avea{' '}
+            <strong>link-uri către resurse mai detaliate</strong>. Din această
+            cauză, principala responsabilitate la partea de învățare este a ta.{' '}
           </p>
           <blockquote>
-            Ne așteptăm să fii motivat
-            și autodidact, să poți înțelege în mare conceptele de unul singur.
+            Ne așteptăm să fii motivat și autodidact, să poți înțelege în mare
+            conceptele de unul singur.
           </blockquote>
           <p>
-            Pentru a învăța cât mai mult, începe cu lecția 0 (cea pe care o citești acum)
-            și continuă pe rând cu fiecare lecție nouă. Citește rezumatul nostru, iar
-            apoi aruncă un ochi pe resursele suplimentare, înainte să te apuci
-            de exerciții.
-            {' '}
+            Pentru a învăța cât mai mult, începe cu lecția 0 (cea pe care o
+            citești acum) și continuă pe rând cu fiecare lecție nouă. Citește
+            rezumatul nostru, iar apoi aruncă un ochi pe resursele suplimentare,
+            înainte să te apuci de exerciții.{' '}
           </p>
           <p>
             <strong>
-              Este foarte important să rezolvi toate exercițiile
-              de la fiecare lecție.
+              Este foarte important să rezolvi toate exercițiile de la fiecare
+              lecție.
+            </strong>{' '}
+            Ai răbdare și încredere în noi, nu am încărcat site-ul cu exerciții
+            inutile.
+          </p>
+          <p>
+            Apoi, după ce ne trimiți soluția ta vom ajunge la{' '}
+            <strong>partea de feedback</strong>. Fiind începător probabil vor fi
+            undeva la 3-4-5 runde, în care-ți vom explica de ce anumite lucruri
+            nu sunt bune și te vom ruga să le schimbi.
+          </p>
+          <p>
+            E extrem de important să{' '}
+            <strong>
+              ai răbdare cu acest proces, și să nu fii prea dur cu tine
             </strong>
-            {' '}
-            Ai răbdare și încredere în noi, nu am încărcat site-ul cu exerciții inutile.
-          </p>
-          <p>
-            Apoi, după ce ne trimiți soluția ta vom ajunge la
-            {' '}
-            <strong>partea de feedback</strong>
-            .
-            Fiind începător probabil vor fi undeva la 3-4-5 runde,
-            în care-ți vom explica de ce anumite lucruri nu sunt
-            bune și te vom ruga să le schimbi.
-          </p>
-          <p>
-            E extrem de important
-            să
-            {' '}
-            <strong>ai răbdare cu acest proces, și să nu fii prea dur cu tine</strong>
-            .
-            Bucură-te că ai pe cineva care-ți face Code Review și de la
-            care poți să înveți. Mulți dintre noi nu am avut șansa asta.
-            Și din nou:
+            . Bucură-te că ai pe cineva care-ți face Code Review și de la care
+            poți să înveți. Mulți dintre noi nu am avut șansa asta. Și din nou:
           </p>
           <blockquote className="is--center">
-            Don't be too hard on yourself.
-            Don't take it personal.
-            Noi suntem aici să te ajutăm. 😄
+            Don't be too hard on yourself. Don't take it personal. Noi suntem
+            aici să te ajutăm. 😄
           </blockquote>
         </section>
         <section>
@@ -269,58 +242,63 @@ export default function Lesson0() {
             Tool-uri necesare
           </LessonHeading>
           <p>
-            Unul dintre cele mai faine lucruri la FrontEnd development
-            este faptul că nu avem nevoie de prea multe lucruri înainte să începem.
-            În primul rând, un
-            {' '}
-            <strong>calculator</strong>
-            {' '}
-            și o
-            {' '}
-            <strong>conexiune la internet</strong>
-            .
+            Unul dintre cele mai faine lucruri la FrontEnd development este
+            faptul că nu avem nevoie de prea multe lucruri înainte să începem.
+            În primul rând, un <strong>calculator</strong> și o{' '}
+            <strong>conexiune la internet</strong>.
           </p>
           <p> Apoi, specific pentru acest domeniu ai nevoie de:</p>
           <ol className="with--count">
             <li>
               <strong>un browser modern și cross-platform </strong>
-              (ce poate fi instalat pe
-              Windows, MacOS și Linux).
+              (ce poate fi instalat pe Windows, MacOS și Linux).
               <p>
-                Noi recomandăm unul dintre
-                {' '}
-                <a target="_blank" rel="noreferrer" href="https://www.google.com/chrome/">
+                Noi recomandăm unul dintre{' '}
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  href="https://www.google.com/chrome/"
+                >
                   Google Chrome
                 </a>
-                ,
-                {' '}
-                <a target="_blank" rel="noreferrer" href="https://www.mozilla.org/en-US/firefox/new/">Mozilla Firefox</a>
+                ,{' '}
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  href="https://www.mozilla.org/en-US/firefox/new/"
+                >
+                  Mozilla Firefox
+                </a>
                 {'  '}
-                sau
-                {' '}
-                <a target="_blank" rel="noreferrer" href="https://www.microsoft.com/en-us/edge">Microsoft Edge</a>
-                .
-                {' '}
-                Nu prea contează pe care din cele 3 îl instalezi, toate sunt bune.
+                sau{' '}
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  href="https://www.microsoft.com/en-us/edge"
+                >
+                  Microsoft Edge
+                </a>
+                . Nu prea contează pe care din cele 3 îl instalezi, toate sunt
+                bune.
               </p>
             </li>
             <li>
-              <a target="_blank" rel="noreferrer" href="https://code.visualstudio.com/download">Visual Studio Code</a>
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://code.visualstudio.com/download"
+              >
+                Visual Studio Code
+              </a>
               : programul unde vom scrie efectiv codul.
-
               <p>
                 {' '}
-                Acest editor este
-                extrem de popular printre developeri, așa că hai să-l folosim chiar de la
-                început pentru a ne familiariza cu el.
-                De asemenea, înainte să începi
-                {' '}
-                <a href="/html/despre-html">Lecția 1</a>
-                {' '}
-                te invităm să arunci un ochi pe acest
-                {' '}
-                <a href="/intro/vs-code">mini-tutorial despre VSCode</a>
-                .
+                Acest editor este extrem de popular printre developeri, așa că
+                hai să-l folosim chiar de la început pentru a ne familiariza cu
+                el. De asemenea, înainte să începi{' '}
+                <a href="/html/despre-html">Lecția 1</a> te invităm să arunci un
+                ochi pe acest{' '}
+                <a href="/intro/vs-code">mini-tutorial despre VSCode</a>.
               </p>
             </li>
           </ol>
@@ -331,30 +309,37 @@ export default function Lesson0() {
             Resurse recomandate
           </LessonHeading>
           <p>
-            Pe partea de resurse, vom adăuga la finalul fiecărei lecții link-uri de
-            unde poți învăța mai multe. Totuși, nu putem să nu menționăm două site-uri extrem de
-            utile și fără de care job-ul de FrontEnd developer ar fi mult mai frustrant:
+            Pe partea de resurse, vom adăuga la finalul fiecărei lecții link-uri
+            de unde poți învăța mai multe. Totuși, nu putem să nu menționăm două
+            site-uri extrem de utile și fără de care job-ul de FrontEnd
+            developer ar fi mult mai frustrant:
           </p>
           <ol className="with--count">
             <li>
-              <a target="_blank" rel="noreferrer" href="https://developer.mozilla.org/en-US/" className="text-bold">MDN - Mozilla Developer Network</a>
-              {' '}
-              este locul unde găsim cele mai calitative și detaliate documentații despre HTML,
-              CSS și JavaScript - cele 3 limbaje ce compun FrontEnd development-ul.
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://developer.mozilla.org/en-US/"
+                className="text-bold"
+              >
+                MDN - Mozilla Developer Network
+              </a>{' '}
+              este locul unde găsim cele mai calitative și detaliate
+              documentații despre HTML, CSS și JavaScript - cele 3 limbaje ce
+              compun FrontEnd development-ul.
               <p>
-                Domeniul e atât de complex încât e perfect normal să nu ținem minte totul.
-                E mult mai comun decât ai crede ca developeri cu experiență să uite
-                lucruri de sintaxă, adică ce bucată de cod trebuie să folosească pentru
-                a ajunge la un anumit rezultat.
+                Domeniul e atât de complex încât e perfect normal să nu ținem
+                minte totul. E mult mai comun decât ai crede ca developeri cu
+                experiență să uite lucruri de sintaxă, adică ce bucată de cod
+                trebuie să folosească pentru a ajunge la un anumit rezultat.
               </p>
               <p>
-                De exemplu, poate am uitat cum schimbăm culoarea de fundal
-                a unui element din pagină, caz în care vom căuta
-                {' '}
-                <span className="formatted">background color MDN</span>
-                .
-                Recomandăm să pui “MDN” la final pentru ca pagina căutată
-                să apară printre primele rezultate.
+                De exemplu, poate am uitat cum schimbăm culoarea de fundal a
+                unui element din pagină, caz în care vom căuta{' '}
+                {/* <span className="formatted">background color MDN</span> */}
+                <FormattedText as="span">background color MDN</FormattedText>.
+                Recomandăm să pui “MDN” la final pentru ca pagina căutată să
+                apară printre primele rezultate.
               </p>
               <LessonFigure
                 withBorder
@@ -362,8 +347,8 @@ export default function Lesson0() {
                 alt="Cautând `background-color MDN` pe Google"
               />
               <p>
-                And voilà! Am ajuns la documentație,
-                unde putem vedea toate opțiunile posibile și cum le putem folosi:
+                And voilà! Am ajuns la documentație, unde putem vedea toate
+                opțiunile posibile și cum le putem folosi:
               </p>
               <LessonFigure
                 withBorder
@@ -372,29 +357,49 @@ export default function Lesson0() {
               />
             </li>
             <li>
-              <a target="_blank" rel="noreferrer" href="https://stackoverflow.com/" className="text-bold">Stack Overflow</a>
-              {' '}
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://stackoverflow.com/"
+                className="text-bold"
+              >
+                Stack Overflow
+              </a>{' '}
               este o comunitate de developeri ce învață și codează împreună.
               <p>
                 Mai exact, este cea mai populară platformă de întrebări și
-                răspunsuri de programare, folosită de mai toți developerii din lume.
-                Fără acest site ne-ar lua mult
-                mai mult timp să gasim soluții la diversele
-                buguri/probleme pe care le întâlnim când codăm.
+                răspunsuri de programare, folosită de mai toți developerii din
+                lume. Fără acest site ne-ar lua mult mai mult timp să gasim
+                soluții la diversele buguri/probleme pe care le întâlnim când
+                codăm.
               </p>
               <p>
                 {' '}
-                Iar dacă ești curios, poți arunca un ochi pe ultimele întrebări adăugate pentru
-                limbajele ce le vom învăța aici:
-                {' '}
-                <a target="_blank" rel="noreferrer" href="https://stackoverflow.com/questions/tagged/html">HTML</a>
-                ,
-                {' '}
-                <a target="_blank" rel="noreferrer" href="https://stackoverflow.com/questions/tagged/css">CSS</a>
-                {' '}
-                si
-                {' '}
-                <a target="_blank" rel="noreferrer" href="https://stackoverflow.com/questions/tagged/javascript">JavaScript</a>
+                Iar dacă ești curios, poți arunca un ochi pe ultimele întrebări
+                adăugate pentru limbajele ce le vom învăța aici:{' '}
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  href="https://stackoverflow.com/questions/tagged/html"
+                >
+                  HTML
+                </a>
+                ,{' '}
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  href="https://stackoverflow.com/questions/tagged/css"
+                >
+                  CSS
+                </a>{' '}
+                si{' '}
+                <a
+                  target="_blank"
+                  rel="noreferrer"
+                  href="https://stackoverflow.com/questions/tagged/javascript"
+                >
+                  JavaScript
+                </a>
                 .
               </p>
             </li>

--- a/client/curriculum/intro/vs-code.tsx
+++ b/client/curriculum/intro/vs-code.tsx
@@ -11,6 +11,7 @@ import Lesson, {
 } from '~/components/lessons';
 import { Diana } from '~/services/contributors';
 import { getLessonById } from '~/services/Constants';
+import FormattedText from '~/components/FormattedText';
 
 const contributors = [Diana];
 const chapters = [
@@ -38,10 +39,18 @@ export default function VSCodeLesson() {
         description={lesson.description}
         url={`https://FrontEnd.ro/${lesson.url}`}
       />
-      <Lesson id="vs-code" withExercises={false} title={lesson.title} chapters={chapters}>
+      <Lesson
+        id="vs-code"
+        withExercises={false}
+        title={lesson.title}
+        chapters={chapters}
+      >
         <LessonContributors className="absolute" contributors={contributors} />
         <LessonCover>
-          <img src={`${process.env.CLOUDFRONT_PUBLIC}/seo/vs-code.jpg`} alt="Logo-ul VSCode" />
+          <img
+            src={`${process.env.CLOUDFRONT_PUBLIC}/seo/vs-code.jpg`}
+            alt="Logo-ul VSCode"
+          />
         </LessonCover>
         <section>
           <h2> Introducere </h2>
@@ -50,40 +59,28 @@ export default function VSCodeLesson() {
           </LessonHeading>
           <p>
             A învăța programare poate părea intimidant, mai ales pentru cei ce
-            vin din domenii cu totul diferite. Ei bine, ținem să te anunțăm că ai
-            ajuns fix la locul potrivit, întrucât noi, developeri cu experiență,
-            te vom îndruma ca acest proces să fie unul cât mai interactiv și
-            plăcut.
+            vin din domenii cu totul diferite. Ei bine, ținem să te anunțăm că
+            ai ajuns fix la locul potrivit, întrucât noi, developeri cu
+            experiență, te vom îndruma ca acest proces să fie unul cât mai
+            interactiv și plăcut.
           </p>
           <p>
-            Ca să fim aliniați în acest proces de învățare ne vom folosi de un
-            {' '}
-            <strong>tool</strong>
-            {' '}
-            ce are mare succes
-            printre developeri și anume
-            {' '}
-            <a href="https://code.visualstudio.com/" target="_blank" rel="noreferrer">
-              <strong>
-                Visual Studio Code
-              </strong>
-            </a>
-            {' '}
-            .
-            Acesta este un editor de cod
-            {' '}
-            <strong>open source</strong>
-            {' '}
-            , ce oferă foarte
-            multe facilități pentru a ne ajuta să codăm rapid. Rulează pe
-            desktop și este disponibil pentru toate sistemele de operare.
+            Ca să fim aliniați în acest proces de învățare ne vom folosi de un{' '}
+            <strong>tool</strong> ce are mare succes printre developeri și anume{' '}
+            <a
+              href="https://code.visualstudio.com/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <strong>Visual Studio Code</strong>
+            </a>{' '}
+            . Acesta este un editor de cod <strong>open source</strong> , ce
+            oferă foarte multe facilități pentru a ne ajuta să codăm rapid.
+            Rulează pe desktop și este disponibil pentru toate sistemele de
+            operare.
           </p>
           <p>
-            Este extrem de popular pentru partea de
-            {' '}
-            <strong>FrontEnd</strong>
-            {' '}
-            ,
+            Este extrem de popular pentru partea de <strong>FrontEnd</strong> ,
             dar printr-o serie de extensii poate fi folosit și pentru alte
             limbaje/tehnologii.
           </p>
@@ -116,15 +113,8 @@ export default function VSCodeLesson() {
           <p>Ok, acum că l-am instalat, vom deschide VS Code.</p>
           <p>
             Haideți să deschidem un proiect în VS Code. Ca să facem asta, putem
-            să-l tragem cu
-            {' '}
-            <strong>drag and drop</strong>
-            {' '}
-            sau putem alege opțiunea
-            {' '}
-            <strong>Open Folder</strong>
-            {' '}
-            .
+            să-l tragem cu <strong>drag and drop</strong> sau putem alege
+            opțiunea <strong>Open Folder</strong> .
           </p>
           <LessonFigure
             isVideo
@@ -142,12 +132,10 @@ export default function VSCodeLesson() {
             alt="Folderul și tot ce acesta conține."
           />
           <p>
-            Ca să creem un nou fișier, fie vom alege
-            {' '}
-            <strong className="formatted">New file</strong>
-            {' '}
-            (CTRL + N), fie vom
-            selecta prima iconiță (de lângă denumirea proiectului).
+            Ca să creem un nou fișier, fie vom alege{' '}
+            {/* <strong className="formatted">New file</strong> */}
+            <FormattedText as="strong">New file</FormattedText> (CTRL + N), fie
+            vom selecta prima iconiță (de lângă denumirea proiectului).
           </p>
           <LessonFigure
             withBorder
@@ -157,20 +145,9 @@ export default function VSCodeLesson() {
           <LessonTip>
             În funcție de ce tip de fișier avem nevoie în proiectul nostru vom
             folosi extensia corespunzătoare. Fișierele de tip HTML vor avea
-            extensia
-            {' '}
-            <strong>.html</strong>
-            {' '}
-            (ca în exemplul de mai sus),
-            fișierele de tip CSS vor avea extensia
-            {' '}
-            <strong>.css</strong>
-            {' '}
-            , iar
-            cele de Javascript vor avea extensia
-            {' '}
-            <strong>.js</strong>
-            . Putem
+            extensia <strong>.html</strong> (ca în exemplul de mai sus),
+            fișierele de tip CSS vor avea extensia <strong>.css</strong> , iar
+            cele de Javascript vor avea extensia <strong>.js</strong>. Putem
             folosi ce limbaj de programare dorim, momentan doar cele trei fac
             obiectul discuției noastre.
           </LessonTip>
@@ -185,10 +162,8 @@ export default function VSCodeLesson() {
             de codare pe care le oferă editorul și despre care e bine să știm.
           </p>
           <p>
-            În partea din stânga a ecranului avem
-            {' '}
-            <strong>Bara de Activitate</strong>
-            :
+            În partea din stânga a ecranului avem{' '}
+            <strong>Bara de Activitate</strong>:
           </p>
           <LessonFigure
             withBorder
@@ -197,59 +172,30 @@ export default function VSCodeLesson() {
           />
           <ol className="with--count">
             <li>
-              Începem cu prima opțiune de sus denumită
-              {' '}
-              <strong>File Explorer</strong>
-              {' '}
-              , unde vom
-              găsi folderele și fișierele curente ale proiectului nostru.
+              Începem cu prima opțiune de sus denumită{' '}
+              <strong>File Explorer</strong> , unde vom găsi folderele și
+              fișierele curente ale proiectului nostru.
             </li>
             <li>
-              Continuăm cu
-              {' '}
-              <strong>Search</strong>
-              {' '}
-              ,
-              pentru a putea căuta global, adică în toate folderele și fișierele
-              noastre.
+              Continuăm cu <strong>Search</strong> , pentru a putea căuta
+              global, adică în toate folderele și fișierele noastre.
             </li>
             <li>
-              <strong>Source Control</strong>
-              {' '}
-              este locul unde putem
-              putem colabora via
-              {' '}
-              <strong>
-                Git
-              </strong>
-              , folosind o interfață vizuală. (PS: dacă nu știi Git poate
-              {' '}
+              <strong>Source Control</strong> este locul unde putem putem
+              colabora via <strong>Git</strong>, folosind o interfață vizuală.
+              (PS: dacă nu știi Git poate{' '}
               <Link href="/slides/git-incepatori">
-                <a>
-                  slide-urile de la trainingul pe care l-am ținut
-                </a>
-              </Link>
-              {' '}
+                <a>slide-urile de la trainingul pe care l-am ținut</a>
+              </Link>{' '}
               o să te ajute)
             </li>
             <li>
-              <strong>Extensions View</strong>
-              {' '}
-              - de unde
-              putem descărca programe
-              {' '}
-              <strong>
-                create de comunitate
-              </strong>
-              {' '}
-              (numite extensii) care extind acest editor cu funcționalități suplimentare.
-              Povestim mai multe
-              despre ele
-              {' '}
+              <strong>Extensions View</strong> - de unde putem descărca programe{' '}
+              <strong>create de comunitate</strong> (numite extensii) care
+              extind acest editor cu funcționalități suplimentare. Povestim mai
+              multe despre ele{' '}
               <Link href="#extensii">
-                <a>
-                  mai jos
-                </a>
+                <a>mai jos</a>
               </Link>
               .
             </li>
@@ -260,25 +206,22 @@ export default function VSCodeLesson() {
             Scurtături
           </LessonHeading>
           <p>
-            Ca și programatori
-            e foarte important
-            ca tool-urile pe care le folosim să ne crească productivitatea,
-            mai ales când vine vorba de taskuri foarte repetitive.
+            Ca și programatori e foarte important ca tool-urile pe care le
+            folosim să ne crească productivitatea, mai ales când vine vorba de
+            taskuri foarte repetitive.
           </p>
           <p>
             De aceea, fiecare editor de cod vine cu o serie de Shortcut-uri
-            (scurtături), adică combinații
-            de taste care împreună fac anumite acțiuni.
-            E posibil ca la început să fii obșnuit să faci
-            totul cu mouse-ul, dar crede-ne pe cuvânt
-            (de fapt nu ne crede, uită-te la alți progamatori
-            când codează) și ai să vezi că folosesc cât de mult
+            (scurtături), adică combinații de taste care împreună fac anumite
+            acțiuni. E posibil ca la început să fii obșnuit să faci totul cu
+            mouse-ul, dar crede-ne pe cuvânt (de fapt nu ne crede, uită-te la
+            alți progamatori când codează) și ai să vezi că folosesc cât de mult
             se poate tastatura.
           </p>
 
           <p>
-            Mai jos îți lăsăm 3 combinații de taste
-            foarte importante, pe care îți sugerăm să le înveți și folosești:
+            Mai jos îți lăsăm 3 combinații de taste foarte importante, pe care
+            îți sugerăm să le înveți și folosești:
           </p>
           <LessonFigure
             withBorder
@@ -296,18 +239,9 @@ export default function VSCodeLesson() {
             comunitate și să respectăm cele mai bune practici.
           </p>
           <p>
-            Pentru a face lucrul acesta vom folosi comanda
-            {' '}
-            <strong> Format Document </strong>
-            {' '}
-            din
-            {' '}
-            <strong>
-              Command Palette
-            </strong>
-            {' '}
-            (vezi shortcut-urile de mai sus)
-            .
+            Pentru a face lucrul acesta vom folosi comanda{' '}
+            <strong> Format Document </strong> din{' '}
+            <strong>Command Palette</strong> (vezi shortcut-urile de mai sus) .
           </p>
           <LessonFigure
             isVideo
@@ -322,23 +256,13 @@ export default function VSCodeLesson() {
           </LessonHeading>
           <p>
             Până acum am rulat manual o comandă pentru a formata codul nostru.
-            Dar putem automatiza acest proces să se întâmple de fiecare
-            dată când dăm Save (Ctrl + S).
+            Dar putem automatiza acest proces să se întâmple de fiecare dată
+            când dăm Save (Ctrl + S).
           </p>
           <p>
-            În secțiunea
-            {' '}
-            <strong>User Settings</strong>
-            {' '}
-            (la care putem ajunge din
-            {' '}
-            <strong>Command Pallete</strong>
-            )
-            putem găsi opțiunea
-            {' '}
-            <strong>Format On Save</strong>
-            {' '}
-            și să o bifăm.
+            În secțiunea <strong>User Settings</strong> (la care putem ajunge
+            din <strong>Command Pallete</strong>) putem găsi opțiunea{' '}
+            <strong>Format On Save</strong> și să o bifăm.
           </p>
           <LessonFigure
             withBorder
@@ -351,9 +275,9 @@ export default function VSCodeLesson() {
             Extensii
           </LessonHeading>
           <p>
-            Extensiile ne permit să adăugăm diverse funcționalități care să vină în sprijinul
-            dezvoltării codului. Cum ziceam și în introducere, de obicei sunt
-            scrise de comunitate și open-source.
+            Extensiile ne permit să adăugăm diverse funcționalități care să vină
+            în sprijinul dezvoltării codului. Cum ziceam și în introducere, de
+            obicei sunt scrise de comunitate și open-source.
           </p>
           <LessonFigure
             withBorder
@@ -372,24 +296,18 @@ export default function VSCodeLesson() {
             alt="Extensii"
           />
           <p>
-            Să luăm spre exemplu extensia
-            {' '}
+            Să luăm spre exemplu extensia{' '}
             <a
               href="https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer"
               target="_blank"
               rel="noreferrer"
             >
               <strong>Live Server</strong>
-            </a>
-            {' '}
-            .
-            Aceasta pornește un
-            {' '}
-            <em>server de dezvoltare local</em>
-            {' '}
-            ce va da refresh la pagină în browser de fiecare dată când
-            modificăm ceva în fișier. Deci nu mai trebuie noi să ținem minte
-            să facem asta pentru a vedea ultimele modificări.
+            </a>{' '}
+            . Aceasta pornește un <em>server de dezvoltare local</em> ce va da
+            refresh la pagină în browser de fiecare dată când modificăm ceva în
+            fișier. Deci nu mai trebuie noi să ținem minte să facem asta pentru
+            a vedea ultimele modificări.
           </p>
         </section>
         <section>
@@ -399,45 +317,35 @@ export default function VSCodeLesson() {
           <p>
             Sunt multe multe lucruri faine pe care le oferă VS Code. Nu reușim
             să le includem pe toate în această lecție, aici vrem să acoperim
-            lucrurile care contează acum pentru începutul carierei tale de developer.
-            Dar vrem să discutăm un pic și despre partea customizabilă, ca să ne
-            creem un environment cât mai plăcut.
+            lucrurile care contează acum pentru începutul carierei tale de
+            developer. Dar vrem să discutăm un pic și despre partea
+            customizabilă, ca să ne creem un environment cât mai plăcut.
           </p>
           <p>
-            Așa că un feature ce s-ar putea să-ți placă este
-            customizarea paletei de culori.
+            Așa că un feature ce s-ar putea să-ți placă este customizarea
+            paletei de culori.
           </p>
           <ol className="with--count">
             <li>
-              Deschide
-              {' '}
-              <strong>
-                Color Theme
-              </strong>
-              {' '}
-              din
-              {' '}
-              <strong>
-                Command Pallete
-              </strong>
-              .
+              Deschide <strong>Color Theme</strong> din{' '}
+              <strong>Command Pallete</strong>.
             </li>
             <li>
               Folosește tastele up și down pentru a face preview la culorile
               temelor.
             </li>
             <li>
-              Selectează tema pe care o dorești apăsând
-              {' '}
-              <strong>ENTER</strong>
-              .
+              Selectează tema pe care o dorești apăsând <strong>ENTER</strong>.
             </li>
           </ol>
           <p>
-            psst: poți instala și alte teme via Extensii. Nouă ne
-            place foarte mult
-            {' '}
-            <a href="https://draculatheme.com/visual-studio-code" target="_blank" rel="noreferrer">
+            psst: poți instala și alte teme via Extensii. Nouă ne place foarte
+            mult{' '}
+            <a
+              href="https://draculatheme.com/visual-studio-code"
+              target="_blank"
+              rel="noreferrer"
+            >
               Dracula Theme 🧛‍♂️
             </a>
           </p>

--- a/client/curriculum/intro/vs-code.tsx
+++ b/client/curriculum/intro/vs-code.tsx
@@ -65,22 +65,35 @@ export default function VSCodeLesson() {
             interactiv și plăcut.
           </p>
           <p>
-            Ca să fim aliniați în acest proces de învățare ne vom folosi de un{' '}
-            <strong>tool</strong> ce are mare succes printre developeri și anume{' '}
+            Ca să fim aliniați în acest proces de învățare ne vom folosi de un
+            {' '}
+            <strong>tool</strong>
+            {' '}
+            ce are mare succes printre developeri și anume
+            {' '}
             <a
               href="https://code.visualstudio.com/"
               target="_blank"
               rel="noreferrer"
             >
               <strong>Visual Studio Code</strong>
-            </a>{' '}
-            . Acesta este un editor de cod <strong>open source</strong> , ce
+            </a>
+            {' '}
+            . Acesta este un editor de cod
+            {' '}
+            <strong>open source</strong>
+            {' '}
+            , ce
             oferă foarte multe facilități pentru a ne ajuta să codăm rapid.
             Rulează pe desktop și este disponibil pentru toate sistemele de
             operare.
           </p>
           <p>
-            Este extrem de popular pentru partea de <strong>FrontEnd</strong> ,
+            Este extrem de popular pentru partea de
+            {' '}
+            <strong>FrontEnd</strong>
+            {' '}
+            ,
             dar printr-o serie de extensii poate fi folosit și pentru alte
             limbaje/tehnologii.
           </p>
@@ -113,8 +126,16 @@ export default function VSCodeLesson() {
           <p>Ok, acum că l-am instalat, vom deschide VS Code.</p>
           <p>
             Haideți să deschidem un proiect în VS Code. Ca să facem asta, putem
-            să-l tragem cu <strong>drag and drop</strong> sau putem alege
-            opțiunea <strong>Open Folder</strong> .
+            să-l tragem cu
+            {' '}
+            <strong>drag and drop</strong>
+            {' '}
+            sau putem alege
+            opțiunea
+            {' '}
+            <strong>Open Folder</strong>
+            {' '}
+            .
           </p>
           <LessonFigure
             isVideo
@@ -132,9 +153,12 @@ export default function VSCodeLesson() {
             alt="Folderul și tot ce acesta conține."
           />
           <p>
-            Ca să creem un nou fișier, fie vom alege{' '}
+            Ca să creem un nou fișier, fie vom alege
+            {' '}
             {/* <strong className="formatted">New file</strong> */}
-            <FormattedText as="strong">New file</FormattedText> (CTRL + N), fie
+            <FormattedText as="strong">New file</FormattedText>
+            {' '}
+            (CTRL + N), fie
             vom selecta prima iconiță (de lângă denumirea proiectului).
           </p>
           <LessonFigure
@@ -145,9 +169,20 @@ export default function VSCodeLesson() {
           <LessonTip>
             În funcție de ce tip de fișier avem nevoie în proiectul nostru vom
             folosi extensia corespunzătoare. Fișierele de tip HTML vor avea
-            extensia <strong>.html</strong> (ca în exemplul de mai sus),
-            fișierele de tip CSS vor avea extensia <strong>.css</strong> , iar
-            cele de Javascript vor avea extensia <strong>.js</strong>. Putem
+            extensia
+            {' '}
+            <strong>.html</strong>
+            {' '}
+            (ca în exemplul de mai sus),
+            fișierele de tip CSS vor avea extensia
+            {' '}
+            <strong>.css</strong>
+            {' '}
+            , iar
+            cele de Javascript vor avea extensia
+            {' '}
+            <strong>.js</strong>
+            . Putem
             folosi ce limbaj de programare dorim, momentan doar cele trei fac
             obiectul discuției noastre.
           </LessonTip>
@@ -162,8 +197,10 @@ export default function VSCodeLesson() {
             de codare pe care le oferă editorul și despre care e bine să știm.
           </p>
           <p>
-            În partea din stânga a ecranului avem{' '}
-            <strong>Bara de Activitate</strong>:
+            În partea din stânga a ecranului avem
+            {' '}
+            <strong>Bara de Activitate</strong>
+            :
           </p>
           <LessonFigure
             withBorder
@@ -172,28 +209,47 @@ export default function VSCodeLesson() {
           />
           <ol className="with--count">
             <li>
-              Începem cu prima opțiune de sus denumită{' '}
-              <strong>File Explorer</strong> , unde vom găsi folderele și
+              Începem cu prima opțiune de sus denumită
+              {' '}
+              <strong>File Explorer</strong>
+              {' '}
+              , unde vom găsi folderele și
               fișierele curente ale proiectului nostru.
             </li>
             <li>
-              Continuăm cu <strong>Search</strong> , pentru a putea căuta
+              Continuăm cu
+              {' '}
+              <strong>Search</strong>
+              {' '}
+              , pentru a putea căuta
               global, adică în toate folderele și fișierele noastre.
             </li>
             <li>
-              <strong>Source Control</strong> este locul unde putem putem
-              colabora via <strong>Git</strong>, folosind o interfață vizuală.
-              (PS: dacă nu știi Git poate{' '}
+              <strong>Source Control</strong>
+              {' '}
+              este locul unde putem putem
+              colabora via
+              <strong>Git</strong>
+              , folosind o interfață vizuală.
+              (PS: dacă nu știi Git poate
+              {' '}
               <Link href="/slides/git-incepatori">
                 <a>slide-urile de la trainingul pe care l-am ținut</a>
-              </Link>{' '}
+              </Link>
+              {' '}
               o să te ajute)
             </li>
             <li>
-              <strong>Extensions View</strong> - de unde putem descărca programe{' '}
-              <strong>create de comunitate</strong> (numite extensii) care
+              <strong>Extensions View</strong>
+              {' '}
+              - de unde putem descărca programe
+              {' '}
+              <strong>create de comunitate</strong>
+              {' '}
+              (numite extensii) care
               extind acest editor cu funcționalități suplimentare. Povestim mai
-              multe despre ele{' '}
+              multe despre ele
+              {' '}
               <Link href="#extensii">
                 <a>mai jos</a>
               </Link>
@@ -239,9 +295,15 @@ export default function VSCodeLesson() {
             comunitate și să respectăm cele mai bune practici.
           </p>
           <p>
-            Pentru a face lucrul acesta vom folosi comanda{' '}
-            <strong> Format Document </strong> din{' '}
-            <strong>Command Palette</strong> (vezi shortcut-urile de mai sus) .
+            Pentru a face lucrul acesta vom folosi comanda
+            {' '}
+            <strong> Format Document </strong>
+            {' '}
+            din
+            {' '}
+            <strong>Command Palette</strong>
+            {' '}
+            (vezi shortcut-urile de mai sus) .
           </p>
           <LessonFigure
             isVideo
@@ -260,9 +322,19 @@ export default function VSCodeLesson() {
             când dăm Save (Ctrl + S).
           </p>
           <p>
-            În secțiunea <strong>User Settings</strong> (la care putem ajunge
-            din <strong>Command Pallete</strong>) putem găsi opțiunea{' '}
-            <strong>Format On Save</strong> și să o bifăm.
+            În secțiunea
+            {' '}
+            <strong>User Settings</strong>
+            {' '}
+            (la care putem ajunge
+            din
+            {' '}
+            <strong>Command Pallete</strong>
+            ) putem găsi opțiunea
+            {' '}
+            <strong>Format On Save</strong>
+            {' '}
+            și să o bifăm.
           </p>
           <LessonFigure
             withBorder
@@ -296,15 +368,21 @@ export default function VSCodeLesson() {
             alt="Extensii"
           />
           <p>
-            Să luăm spre exemplu extensia{' '}
+            Să luăm spre exemplu extensia
+            {' '}
             <a
               href="https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer"
               target="_blank"
               rel="noreferrer"
             >
               <strong>Live Server</strong>
-            </a>{' '}
-            . Aceasta pornește un <em>server de dezvoltare local</em> ce va da
+            </a>
+            {' '}
+            . Aceasta pornește un
+            {' '}
+            <em>server de dezvoltare local</em>
+            {' '}
+            ce va da
             refresh la pagină în browser de fiecare dată când modificăm ceva în
             fișier. Deci nu mai trebuie noi să ținem minte să facem asta pentru
             a vedea ultimele modificări.
@@ -327,20 +405,30 @@ export default function VSCodeLesson() {
           </p>
           <ol className="with--count">
             <li>
-              Deschide <strong>Color Theme</strong> din{' '}
-              <strong>Command Pallete</strong>.
+              Deschide
+              {' '}
+              <strong>Color Theme</strong>
+              {' '}
+              din
+              {' '}
+              <strong>Command Pallete</strong>
+              .
             </li>
             <li>
               Folosește tastele up și down pentru a face preview la culorile
               temelor.
             </li>
             <li>
-              Selectează tema pe care o dorești apăsând <strong>ENTER</strong>.
+              Selectează tema pe care o dorești apăsând
+              {' '}
+              <strong>ENTER</strong>
+              .
             </li>
           </ol>
           <p>
             psst: poți instala și alte teme via Extensii. Nouă ne place foarte
-            mult{' '}
+            mult
+            {' '}
             <a
               href="https://draculatheme.com/visual-studio-code"
               target="_blank"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": false,
   "engines": {
-    "node": "16.1.0"
+    "node": "16.4.2"
   },
   "author": {
     "name": "Alexandru Pavaloi",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": false,
   "engines": {
-    "node": "16.4.2"
+    "node": "16.1.0"
   },
   "author": {
     "name": "Alexandru Pavaloi",

--- a/pages/demo/css/css-inline.tsx
+++ b/pages/demo/css/css-inline.tsx
@@ -5,6 +5,7 @@ import Header from '~/components/Header';
 import Footer from '~/components/Footer';
 import Highlight from '~/components/Highlight/Highlight';
 import SEOTags from '~/components/SEOTags';
+import FormattedText from '~/components/FormattedText';
 
 export default function InlineMethod() {
   const title = 'CSS Inline';
@@ -20,43 +21,56 @@ export default function InlineMethod() {
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Prin
-            {' '}
-            <strong className="formatted">metoda inline</strong>
-            {' '}
-            putem aplica stilul unui singur element HTML.
+            Prin <FormattedText as="strong">metoda inline</FormattedText> putem
+            aplica stilul unui singur element HTML.
           </p>
           <p>
-            Scrierea codului CSS se va face prin adaugarea atributului
-            {' '}
-            <strong className="formatted">style</strong>
-            {' '}
-            pe elementul căruia vrem să-i modificăm stilul:
+            Scrierea codului CSS se va face prin adaugarea atributului{' '}
+            <FormattedText as="strong">style</FormattedText> pe elementul căruia
+            vrem să-i modificăm stilul:
           </p>
           <DemoPreview>
             <div style={{ background: '#282a36', padding: '1em' }}>
-              <h1 style={{
-                textAlign: 'center',
-                fontSize: '45px',
-                fontFamily: 'sans-serif',
-                color: 'white',
-                textShadow: '2px 2px 0 #000',
-              }}
+              <h1
+                style={{
+                  textAlign: 'center',
+                  fontSize: '45px',
+                  fontFamily: 'sans-serif',
+                  color: 'white',
+                  textShadow: '2px 2px 0 #000',
+                }}
               >
                 CSS inline
               </h1>
-              <p style={{
-                color: '#fff', marginLeft: '50px', fontSize: '25px', fontFamily: 'sans-serif',
-              }}
+              <p
+                style={{
+                  color: '#fff',
+                  marginLeft: '50px',
+                  fontSize: '25px',
+                  fontFamily: 'sans-serif',
+                }}
               >
                 Observăm că stilurile sunt destul de greu de citit și editat.
               </p>
-              <p style={{
-                color: '#fff', marginLeft: '50px', fontSize: '27px', fontFamily: 'sans-serif',
-              }}
+              <p
+                style={{
+                  color: '#fff',
+                  marginLeft: '50px',
+                  fontSize: '27px',
+                  fontFamily: 'sans-serif',
+                }}
               >
                 De aceea recomandăm evitarea
-                <span style={{ fontSize: '30px', fontWeight: 'bold', color: '#9f616a' }}> acestei metode </span>
+                <span
+                  style={{
+                    fontSize: '30px',
+                    fontWeight: 'bold',
+                    color: '#9f616a',
+                  }}
+                >
+                  {' '}
+                  acestei metode{' '}
+                </span>
                 .
               </p>
             </div>

--- a/pages/demo/css/css-inline.tsx
+++ b/pages/demo/css/css-inline.tsx
@@ -21,12 +21,19 @@ export default function InlineMethod() {
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Prin <FormattedText as="strong">metoda inline</FormattedText> putem
+            Prin
+            {' '}
+            <FormattedText as="strong">metoda inline</FormattedText>
+            {' '}
+            putem
             aplica stilul unui singur element HTML.
           </p>
           <p>
-            Scrierea codului CSS se va face prin adaugarea atributului{' '}
-            <FormattedText as="strong">style</FormattedText> pe elementul căruia
+            Scrierea codului CSS se va face prin adaugarea atributului
+            {' '}
+            <FormattedText as="strong">style</FormattedText>
+            {' '}
+            pe elementul căruia
             vrem să-i modificăm stilul:
           </p>
           <DemoPreview>
@@ -69,7 +76,8 @@ export default function InlineMethod() {
                   }}
                 >
                   {' '}
-                  acestei metode{' '}
+                  acestei metode
+                  {' '}
                 </span>
                 .
               </p>

--- a/pages/demo/css/css-intern.tsx
+++ b/pages/demo/css/css-intern.tsx
@@ -47,13 +47,21 @@ export default function InternalCSS() {
         <Demo title={title}>
           <p>
             Metoda de integrare a codului CSS în pagina web se va face prin
-            inserarea elementului{' '}
-            <FormattedText as="strong">{'<style>'}</FormattedText> în secțiunea{' '}
-            <FormattedText as="strong">{'<head>'}</FormattedText> a documentului
-            HTML. Față de{' '}
+            inserarea elementului
+            {' '}
+            <FormattedText as="strong">{'<style>'}</FormattedText>
+            {' '}
+            în secțiunea
+            {' '}
+            <FormattedText as="strong">{'<head>'}</FormattedText>
+            {' '}
+            a documentului
+            HTML. Față de
+            {' '}
             <Link href="/demo/css/css-inline">
               <a>metoda inline</a>
-            </Link>{' '}
+            </Link>
+            {' '}
             , la aceasta trebuie să precizăm pentru ce elemente vom aplica
             regulile de stilizare folosind selectori.
           </p>
@@ -63,7 +71,8 @@ export default function InternalCSS() {
                 <h1>Frontend.ro</h1>
                 <p>
                   Învață alături de noi cum
-                  <span> să stilizezi </span>.
+                  <span> să stilizezi </span>
+                  .
                 </p>
               </main>
             </div>

--- a/pages/demo/css/css-intern.tsx
+++ b/pages/demo/css/css-intern.tsx
@@ -6,6 +6,7 @@ import Header from '~/components/Header';
 import Footer from '~/components/Footer';
 import Highlight from '~/components/Highlight/Highlight';
 import SEOTags from '~/components/SEOTags';
+import FormattedText from '~/components/FormattedText';
 
 export default function InternalCSS() {
   const title = 'CSS Intern';
@@ -46,25 +47,15 @@ export default function InternalCSS() {
         <Demo title={title}>
           <p>
             Metoda de integrare a codului CSS în pagina web se va face prin
-            inserarea elementului
-            {' '}
-            <strong className="formatted">{'<style>'}</strong>
-            {' '}
-            în secțiunea
-            {' '}
-            <strong className="formatted">{'<head>'}</strong>
-            {' '}
-            a documentului
-            HTML. Față de
-            {' '}
+            inserarea elementului{' '}
+            <FormattedText as="strong">{'<style>'}</FormattedText> în secțiunea{' '}
+            <FormattedText as="strong">{'<head>'}</FormattedText> a documentului
+            HTML. Față de{' '}
             <Link href="/demo/css/css-inline">
-              <a>
-                metoda inline
-              </a>
-            </Link>
-            {' '}
-            , la aceasta trebuie să precizăm pentru ce elemente
-            vom aplica regulile de stilizare folosind selectori.
+              <a>metoda inline</a>
+            </Link>{' '}
+            , la aceasta trebuie să precizăm pentru ce elemente vom aplica
+            regulile de stilizare folosind selectori.
           </p>
           <DemoPreview>
             <div className="css-intern">
@@ -72,8 +63,7 @@ export default function InternalCSS() {
                 <h1>Frontend.ro</h1>
                 <p>
                   Învață alături de noi cum
-                  <span> să stilizezi </span>
-                  .
+                  <span> să stilizezi </span>.
                 </p>
               </main>
             </div>

--- a/pages/demo/html/atributul-start-pentru-liste-ordonate.tsx
+++ b/pages/demo/html/atributul-start-pentru-liste-ordonate.tsx
@@ -5,29 +5,24 @@ import Demo, { DemoPreview } from '~/components/demo';
 import Header from '~/components/Header';
 import Footer from '~/components/Footer';
 import Highlight from '~/components/Highlight/Highlight';
+import FormattedText from '~/components/FormattedText';
 
 export default function OrderedListsStart() {
-  const title = 'Atributul \'start\' pentru liste ordonate';
+  const title = "Atributul 'start' pentru liste ordonate";
   return (
     <>
       <Head>
-        <title>
-          {title}
-          {' '}
-          | FrontEnd.ro
-        </title>
+        <title>{title} | FrontEnd.ro</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Putem opta să enumerăm elementele unei liste ordonate începând
-            de la un anumit număr/literă folosindu-ne de atributul
-            {' '}
-            <strong className="formatted">start</strong>
-            {' '}
-            dând ca valoare numărul/litera de la care vrem să începem numărătoarea:
+            Putem opta să enumerăm elementele unei liste ordonate începând de la
+            un anumit număr/literă folosindu-ne de atributul{' '}
+            <FormattedText as="strong">start</FormattedText> dând ca valoare
+            numărul/litera de la care vrem să începem numărătoarea:
           </p>
           <DemoPreview>
             <ol>

--- a/pages/demo/html/atributul-start-pentru-liste-ordonate.tsx
+++ b/pages/demo/html/atributul-start-pentru-liste-ordonate.tsx
@@ -12,7 +12,11 @@ export default function OrderedListsStart() {
   return (
     <>
       <Head>
-        <title>{title} | FrontEnd.ro</title>
+        <title>
+          {title}
+          {' '}
+          | FrontEnd.ro
+        </title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
@@ -20,8 +24,11 @@ export default function OrderedListsStart() {
         <Demo title={title}>
           <p>
             Putem opta să enumerăm elementele unei liste ordonate începând de la
-            un anumit număr/literă folosindu-ne de atributul{' '}
-            <FormattedText as="strong">start</FormattedText> dând ca valoare
+            un anumit număr/literă folosindu-ne de atributul
+            {' '}
+            <FormattedText as="strong">start</FormattedText>
+            {' '}
+            dând ca valoare
             numărul/litera de la care vrem să începem numărătoarea:
           </p>
           <DemoPreview>

--- a/pages/demo/html/atributul-type-pentru-liste-ordonate.tsx
+++ b/pages/demo/html/atributul-type-pentru-liste-ordonate.tsx
@@ -5,18 +5,15 @@ import Demo, { DemoPreview } from '~/components/demo';
 import Header from '~/components/Header';
 import Footer from '~/components/Footer';
 import Highlight from '~/components/Highlight/Highlight';
+import FormattedText from '~/components/FormattedText';
 
 export default function OrderedListsType() {
-  const title = 'Atributul \'type\' pentru liste ordonate';
+  const title = "Atributul 'type' pentru liste ordonate";
 
   return (
     <>
       <Head>
-        <title>
-          {title}
-          {' '}
-          | FrontEnd.ro
-        </title>
+        <title>{title} | FrontEnd.ro</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
@@ -24,10 +21,8 @@ export default function OrderedListsType() {
         <Demo title={title}>
           <p>
             Dacă vrem ca enumerarea elementelor din listă să se facă cu un
-            anumit tip de cifră sau cu litere, ne putem folosi de atributul
-            {' '}
-            <strong>type</strong>
-            :
+            anumit tip de cifră sau cu litere, ne putem folosi de atributul{' '}
+            <strong>type</strong>:
           </p>
           <DemoPreview>
             <ol type="I">
@@ -48,30 +43,20 @@ export default function OrderedListsType() {
                    
 `}
           />
-          <p>
-            Acesta acceptă și alte valori:
-          </p>
+          <p>Acesta acceptă și alte valori:</p>
           <ul className="with--bullets">
             <li className="mb-4">
-              <strong className="formatted">1</strong>
-              {' '}
-              – pentru enumerare cu
-              {' '}
+              <FormattedText as="strong">1</FormattedText> – pentru enumerare cu{' '}
               cifre arabe
             </li>
             <li className="mb-4">
-              <strong className="formatted">i</strong>
-              {' '}
-              – pentru enumerare cifre romane mici
+              <FormattedText as="strong">i</FormattedText> – pentru enumerare
+              cifre romane mici
             </li>
             <li>
-              <strong className="formatted">a</strong>
-              {' '}
-              sau
-              {' '}
-              <strong className="formatted">A</strong>
-              {' '}
-              – pentru enumerare cu litere mici, respectiv mari
+              <FormattedText as="strong">a</FormattedText> sau{' '}
+              <FormattedText as="strong">A</FormattedText> – pentru enumerare cu
+              litere mici, respectiv mari
             </li>
           </ul>
         </Demo>

--- a/pages/demo/html/atributul-type-pentru-liste-ordonate.tsx
+++ b/pages/demo/html/atributul-type-pentru-liste-ordonate.tsx
@@ -13,7 +13,11 @@ export default function OrderedListsType() {
   return (
     <>
       <Head>
-        <title>{title} | FrontEnd.ro</title>
+        <title>
+          {title}
+          {' '}
+          | FrontEnd.ro
+        </title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
@@ -21,8 +25,10 @@ export default function OrderedListsType() {
         <Demo title={title}>
           <p>
             Dacă vrem ca enumerarea elementelor din listă să se facă cu un
-            anumit tip de cifră sau cu litere, ne putem folosi de atributul{' '}
-            <strong>type</strong>:
+            anumit tip de cifră sau cu litere, ne putem folosi de atributul
+            {' '}
+            <strong>type</strong>
+            :
           </p>
           <DemoPreview>
             <ol type="I">
@@ -46,16 +52,26 @@ export default function OrderedListsType() {
           <p>Acesta acceptă și alte valori:</p>
           <ul className="with--bullets">
             <li className="mb-4">
-              <FormattedText as="strong">1</FormattedText> – pentru enumerare cu{' '}
+              <FormattedText as="strong">1</FormattedText>
+              {' '}
+              – pentru enumerare cu
+              {' '}
               cifre arabe
             </li>
             <li className="mb-4">
-              <FormattedText as="strong">i</FormattedText> – pentru enumerare
+              <FormattedText as="strong">i</FormattedText>
+              {' '}
+              – pentru enumerare
               cifre romane mici
             </li>
             <li>
-              <FormattedText as="strong">a</FormattedText> sau{' '}
-              <FormattedText as="strong">A</FormattedText> – pentru enumerare cu
+              <FormattedText as="strong">a</FormattedText>
+              {' '}
+              sau
+              {' '}
+              <FormattedText as="strong">A</FormattedText>
+              {' '}
+              – pentru enumerare cu
               litere mici, respectiv mari
             </li>
           </ul>

--- a/pages/demo/html/audio.tsx
+++ b/pages/demo/html/audio.tsx
@@ -5,6 +5,7 @@ import Header from '~/components/Header';
 import Footer from '~/components/Footer';
 import SEOTags from '~/components/SEOTags';
 import Highlight from '~/components/Highlight/Highlight';
+import FormattedText from '~/components/FormattedText';
 
 export default function Audio() {
   const title = 'Elementul <audio>';
@@ -20,11 +21,9 @@ export default function Audio() {
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Exemplu de utilizare a elementului
-            {' '}
-            <strong className="formatted">{'<audio>'}</strong>
-            {' '}
-            ce specifică mai multe surse:
+            Exemplu de utilizare a elementului{' '}
+            <FormattedText as="strong">{'<audio>'}</FormattedText> ce specifică
+            mai multe surse:
           </p>
           <DemoPreview>
             {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
@@ -40,10 +39,12 @@ export default function Audio() {
               />
 
               <p>
-                Browser-ul tău nu suportă fișiere audio.
-                Folosește
-                {' '}
-                <a href={`${process.env.CLOUDFRONT_PUBLIC}/demo-assets/audio-video/big-buck-bunny-audio.mp3`}>acest link</a>
+                Browser-ul tău nu suportă fișiere audio. Folosește{' '}
+                <a
+                  href={`${process.env.CLOUDFRONT_PUBLIC}/demo-assets/audio-video/big-buck-bunny-audio.mp3`}
+                >
+                  acest link
+                </a>
                 pentru a-l putea vizualiza.
               </p>
             </audio>

--- a/pages/demo/html/audio.tsx
+++ b/pages/demo/html/audio.tsx
@@ -21,8 +21,11 @@ export default function Audio() {
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Exemplu de utilizare a elementului{' '}
-            <FormattedText as="strong">{'<audio>'}</FormattedText> ce specifică
+            Exemplu de utilizare a elementului
+            {' '}
+            <FormattedText as="strong">{'<audio>'}</FormattedText>
+            {' '}
+            ce specifică
             mai multe surse:
           </p>
           <DemoPreview>
@@ -39,7 +42,8 @@ export default function Audio() {
               />
 
               <p>
-                Browser-ul tău nu suportă fișiere audio. Folosește{' '}
+                Browser-ul tău nu suportă fișiere audio. Folosește
+                {' '}
                 <a
                   href={`${process.env.CLOUDFRONT_PUBLIC}/demo-assets/audio-video/big-buck-bunny-audio.mp3`}
                 >

--- a/pages/demo/html/citate.tsx
+++ b/pages/demo/html/citate.tsx
@@ -12,16 +12,26 @@ export default function Quotes() {
   return (
     <>
       <Head>
-        <title>{title} | FrontEnd.ro</title>
+        <title>
+          {title}
+          {' '}
+          | FrontEnd.ro
+        </title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Putem folosi{' '}
-            <FormattedText as="strong">{'<blockquote>'}</FormattedText> sau{' '}
-            <FormattedText as="strong">{'<q>'}</FormattedText> pentru a marca
+            Putem folosi
+            {' '}
+            <FormattedText as="strong">{'<blockquote>'}</FormattedText>
+            {' '}
+            sau
+            {' '}
+            <FormattedText as="strong">{'<q>'}</FormattedText>
+            {' '}
+            pentru a marca
             citate.
           </p>
           <DemoPreview>

--- a/pages/demo/html/citate.tsx
+++ b/pages/demo/html/citate.tsx
@@ -5,44 +5,35 @@ import Demo, { DemoPreview } from '~/components/demo';
 import Header from '~/components/Header';
 import Footer from '~/components/Footer';
 import Highlight from '~/components/Highlight/Highlight';
+import FormattedText from '~/components/FormattedText';
 
 export default function Quotes() {
   const title = 'Citate';
   return (
     <>
       <Head>
-        <title>
-          {title}
-          {' '}
-          | FrontEnd.ro
-        </title>
+        <title>{title} | FrontEnd.ro</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Putem folosi
-            {' '}
-            <strong className="formatted">{'<blockquote>'}</strong>
-            {' '}
-            sau
-            {' '}
-            <strong className="formatted">{'<q>'}</strong>
-            {' '}
-            pentru a marca citate.
+            Putem folosi{' '}
+            <FormattedText as="strong">{'<blockquote>'}</FormattedText> sau{' '}
+            <FormattedText as="strong">{'<q>'}</FormattedText> pentru a marca
+            citate.
           </p>
           <DemoPreview>
-            <blockquote
-              cite="https://en.wikipedia.org/wiki/A_journey_of_a_thousand_miles_begins_with_a_single_step"
-            >
+            <blockquote cite="https://en.wikipedia.org/wiki/A_journey_of_a_thousand_miles_begins_with_a_single_step">
               <p> Călătoria de 1000 mile începe cu un singur pas. </p>
             </blockquote>
             <hr />
             <p>
               După cum a spus Roosevelt,
               <q cite="https://www.goodreads.com/quotes/10002-it-is-hard-to-fail-but-it-is-worse-never">
-                It is hard to fail, but it is worse never to have tried to succeed.
+                It is hard to fail, but it is worse never to have tried to
+                succeed.
               </q>
             </p>
           </DemoPreview>

--- a/pages/demo/html/elementul-br.tsx
+++ b/pages/demo/html/elementul-br.tsx
@@ -5,34 +5,24 @@ import Demo, { DemoPreview } from '~/components/demo';
 import Header from '~/components/Header';
 import Footer from '~/components/Footer';
 import Highlight from '~/components/Highlight/Highlight';
+import FormattedText from '~/components/FormattedText';
 
 export default function LineBreak() {
   const title = 'Elementul <br> pentru a adăuga o linie nouă';
   return (
     <>
       <Head>
-        <title>
-          {title}
-          {' '}
-          | FrontEnd.ro
-        </title>
+        <title>{title} | FrontEnd.ro</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Dând
-            {' '}
-            <span className="formatted">Enter</span>
-            {' '}
-            într-un paragraf
-            nu forțează textul pe o nouă linie.
-            Pentru a obține acest rezultat putem crea un nou paragraf, sau să
-            folosim elementul
-            {' '}
-            <strong className="formatted">{'<br>'}</strong>
-            .
+            Dând <FormattedText as="span">Enter</FormattedText> într-un paragraf
+            nu forțează textul pe o nouă linie. Pentru a obține acest rezultat
+            putem crea un nou paragraf, sau să folosim elementul{' '}
+            <FormattedText as="strong">{'<br>'}</FormattedText>.
           </p>
           <DemoPreview>
             <p>

--- a/pages/demo/html/elementul-br.tsx
+++ b/pages/demo/html/elementul-br.tsx
@@ -12,17 +12,27 @@ export default function LineBreak() {
   return (
     <>
       <Head>
-        <title>{title} | FrontEnd.ro</title>
+        <title>
+          {title}
+          {' '}
+          | FrontEnd.ro
+        </title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Dând <FormattedText as="span">Enter</FormattedText> într-un paragraf
+            Dând
+            {' '}
+            <FormattedText as="span">Enter</FormattedText>
+            {' '}
+            într-un paragraf
             nu forțează textul pe o nouă linie. Pentru a obține acest rezultat
-            putem crea un nou paragraf, sau să folosim elementul{' '}
-            <FormattedText as="strong">{'<br>'}</FormattedText>.
+            putem crea un nou paragraf, sau să folosim elementul
+            {' '}
+            <FormattedText as="strong">{'<br>'}</FormattedText>
+            .
           </p>
           <DemoPreview>
             <p>

--- a/pages/demo/html/elementul-hr.tsx
+++ b/pages/demo/html/elementul-hr.tsx
@@ -12,14 +12,21 @@ export default function HorizontalLine() {
   return (
     <>
       <Head>
-        <title>{title} | FrontEnd.ro</title>
+        <title>
+          {title}
+          {' '}
+          | FrontEnd.ro
+        </title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Elementul <FormattedText as="strong">{'<hr>'}</FormattedText>{' '}
+            Elementul
+            {' '}
+            <FormattedText as="strong">{'<hr>'}</FormattedText>
+            {' '}
             (horizontal line) este un separator între secțiuni/elemente din
             pagină. .
           </p>

--- a/pages/demo/html/elementul-hr.tsx
+++ b/pages/demo/html/elementul-hr.tsx
@@ -5,33 +5,23 @@ import Demo, { DemoPreview } from '~/components/demo';
 import Header from '~/components/Header';
 import Footer from '~/components/Footer';
 import Highlight from '~/components/Highlight/Highlight';
+import FormattedText from '~/components/FormattedText';
 
 export default function HorizontalLine() {
   const title = 'Elementul <hr> adaugă o linie de separare';
   return (
     <>
       <Head>
-        <title>
-          {title}
-          {' '}
-          | FrontEnd.ro
-        </title>
+        <title>{title} | FrontEnd.ro</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Elementul
-            {' '}
-            <strong className="formatted">
-              {'<hr>'}
-            </strong>
-            {' '}
-            (horizontal line)
-            este un separator între
-            secțiuni/elemente din pagină.
-            .
+            Elementul <FormattedText as="strong">{'<hr>'}</FormattedText>{' '}
+            (horizontal line) este un separator între secțiuni/elemente din
+            pagină. .
           </p>
           <DemoPreview>
             <p> O primă regulă în această casă: Întotdeauna zîmbește! </p>

--- a/pages/demo/html/linkuri-care-contin-bucati-mari-de-continut.tsx
+++ b/pages/demo/html/linkuri-care-contin-bucati-mari-de-continut.tsx
@@ -10,13 +10,16 @@ import { LessonTip } from '~/components/lessons';
 import FormattedText from '~/components/FormattedText';
 
 export default function LinksAroundBiggerChuncksOfContent() {
-  const title =
-    'Două modalități prin care putem folosi bucăți mari de cod în interiorul unui link și implicațiile lor';
+  const title = 'Două modalități prin care putem folosi bucăți mari de cod în interiorul unui link și implicațiile lor';
 
   return (
     <>
       <Head>
-        <title>{title} | DEMO - FrontEnd.ro</title>
+        <title>
+          {title}
+          {' '}
+          | DEMO - FrontEnd.ro
+        </title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
@@ -30,11 +33,19 @@ export default function LinksAroundBiggerChuncksOfContent() {
             Faptul că îl folosim așa, în interiorul link-ului, duce la
             implicații în ceea ce privește UX-ul. De exemplu, poate fi dificil
             să selectem textul din interior, iar întregul element are nevoie de
-            reguli de stilizare destul de complexe pentru a crea starea de{' '}
-            <i>focus</i> și <i>hover</i>.
+            reguli de stilizare destul de complexe pentru a crea starea de
+            {' '}
+            <i>focus</i>
+            {' '}
+            și
+            <i>hover</i>
+            .
           </p>
           <p>
-            Totodată trebuie să avem în vedere și <i>accesibilitatea</i>, cum ar
+            Totodată trebuie să avem în vedere și
+            {' '}
+            <i>accesibilitatea</i>
+            , cum ar
             fi faptul că întregul conținut va fi citit de către screen readere
             înainte de a fi "anunțat" ca fiind un link.
           </p>
@@ -214,7 +225,9 @@ export default function LinksAroundBiggerChuncksOfContent() {
           />
           <p>
             Al doilea exemplu are un link în titlu și link-ul are un
-            <a href="/css/pseudo-elements"> pseudo-element</a> definit care
+            <a href="/css/pseudo-elements"> pseudo-element</a>
+            {' '}
+            definit care
             "acoperă" întregul card.
           </p>
           <p>
@@ -427,10 +440,16 @@ export default function LinksAroundBiggerChuncksOfContent() {
 `}
           />
           <LessonTip icon={faQuestionCircle}>
-            Atributul <FormattedText as="strong">style</FormattedText> este
+            Atributul
+            {' '}
+            <FormattedText as="strong">style</FormattedText>
+            {' '}
+            este
             folosit pentru a adăuga reguli CSS elementelor. Incă nu am ajuns la
             acel capitol deci e absolut normal să nu știi ce face.
-            <br /> <br />
+            <br />
+            {' '}
+            <br />
             Totuși, te rugăm să-l pui acolo pentru a obține același rezultat ca
             cel de mai sus.
           </LessonTip>

--- a/pages/demo/html/linkuri-care-contin-bucati-mari-de-continut.tsx
+++ b/pages/demo/html/linkuri-care-contin-bucati-mari-de-continut.tsx
@@ -7,18 +7,16 @@ import Header from '~/components/Header';
 import Footer from '~/components/Footer';
 import Highlight from '~/components/Highlight/Highlight';
 import { LessonTip } from '~/components/lessons';
+import FormattedText from '~/components/FormattedText';
 
 export default function LinksAroundBiggerChuncksOfContent() {
-  const title = 'Două modalități prin care putem folosi bucăți mari de cod în interiorul unui link și implicațiile lor';
+  const title =
+    'Două modalități prin care putem folosi bucăți mari de cod în interiorul unui link și implicațiile lor';
 
   return (
     <>
       <Head>
-        <title>
-          {title}
-          {' '}
-          | DEMO - FrontEnd.ro
-        </title>
+        <title>{title} | DEMO - FrontEnd.ro</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
@@ -29,23 +27,14 @@ export default function LinksAroundBiggerChuncksOfContent() {
             unui link.
           </p>
           <p>
-            Faptul că îl folosim așa, în interiorul link-ului, duce la implicații
-            în ceea ce privește UX-ul. De exemplu, poate fi dificil să selectem
-            textul din interior, iar întregul element are nevoie de reguli de
-            stilizare destul de complexe pentru a crea starea de
-            {' '}
-            <i>focus</i>
-            {' '}
-            și
-            {' '}
-            <i>hover</i>
-            .
+            Faptul că îl folosim așa, în interiorul link-ului, duce la
+            implicații în ceea ce privește UX-ul. De exemplu, poate fi dificil
+            să selectem textul din interior, iar întregul element are nevoie de
+            reguli de stilizare destul de complexe pentru a crea starea de{' '}
+            <i>focus</i> și <i>hover</i>.
           </p>
           <p>
-            Totodată trebuie să avem în vedere și
-            {' '}
-            <i>accesibilitatea</i>
-            , cum ar
+            Totodată trebuie să avem în vedere și <i>accesibilitatea</i>, cum ar
             fi faptul că întregul conținut va fi citit de către screen readere
             înainte de a fi "anunțat" ca fiind un link.
           </p>
@@ -63,11 +52,7 @@ export default function LinksAroundBiggerChuncksOfContent() {
                   textAlign: 'center',
                 }}
               >
-                <h2 style={{ fontSize: '30px' }}>
-                  {' '}
-                  Titlu
-                  {' '}
-                </h2>
+                <h2 style={{ fontSize: '30px' }}> Titlu </h2>
                 <div>
                   <svg
                     id="a5349118-8809-40c5-ab34-fa23ee5ede74"
@@ -229,9 +214,7 @@ export default function LinksAroundBiggerChuncksOfContent() {
           />
           <p>
             Al doilea exemplu are un link în titlu și link-ul are un
-            <a href="/css/pseudo-elements"> pseudo-element</a>
-            {' '}
-            definit care
+            <a href="/css/pseudo-elements"> pseudo-element</a> definit care
             "acoperă" întregul card.
           </p>
           <p>
@@ -444,17 +427,12 @@ export default function LinksAroundBiggerChuncksOfContent() {
 `}
           />
           <LessonTip icon={faQuestionCircle}>
-            Atributul
-            {' '}
-            <strong className="formatted">style</strong>
-            {' '}
-            este folosit pentru a adăuga reguli
-            CSS elementelor. Incă nu am ajuns la acel capitol deci e absolut
-            normal să nu știi ce face.
-            <br />
-            {' '}
-            <br />
-            Totuși, te rugăm să-l pui acolo pentru a obține același rezultat ca cel de mai sus.
+            Atributul <FormattedText as="strong">style</FormattedText> este
+            folosit pentru a adăuga reguli CSS elementelor. Incă nu am ajuns la
+            acel capitol deci e absolut normal să nu știi ce face.
+            <br /> <br />
+            Totuși, te rugăm să-l pui acolo pentru a obține același rezultat ca
+            cel de mai sus.
           </LessonTip>
         </Demo>
         <Footer />

--- a/pages/demo/html/noopener-noreferrer-rel.tsx
+++ b/pages/demo/html/noopener-noreferrer-rel.tsx
@@ -5,6 +5,7 @@ import Demo, { DemoPreview } from '~/components/demo';
 import Header from '~/components/Header';
 import Footer from '~/components/Footer';
 import Highlight from '~/components/Highlight/Highlight';
+import FormattedText from '~/components/FormattedText';
 
 export default function NoopenerNoreferrerRel() {
   const title = 'Atributul rel cu valorile noopener și noreferrer';
@@ -12,27 +13,27 @@ export default function NoopenerNoreferrerRel() {
   return (
     <>
       <Head>
-        <title>
-          {title}
-          {' '}
-          | DEMO - FrontEnd.ro
-        </title>
+        <title>{title} | DEMO - FrontEnd.ro</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
         <Header demoPage />
         <Demo title={title}>
           <DemoPreview>
-            <a href="http://frontend.ro" target="_blank" rel="noopener noreferrer">
+            <a
+              href="http://frontend.ro"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               Link-ul se deschide într-un nou tab
             </a>
           </DemoPreview>
           <p>
             Când folosim valoarea _blank, e recomandat să adăugăm un nou atribut
-            pentru securitate și anume :
-            {' '}
-            <strong className="formatted">rel cu valorile ”noopener noreferrer”.</strong>
-            {' '}
+            pentru securitate și anume :{' '}
+            <FormattedText as="strong">
+              rel cu valorile ”noopener noreferrer”.
+            </FormattedText>{' '}
           </p>
           <Highlight
             className="my-5"

--- a/pages/demo/html/noopener-noreferrer-rel.tsx
+++ b/pages/demo/html/noopener-noreferrer-rel.tsx
@@ -13,7 +13,11 @@ export default function NoopenerNoreferrerRel() {
   return (
     <>
       <Head>
-        <title>{title} | DEMO - FrontEnd.ro</title>
+        <title>
+          {title}
+          {' '}
+          | DEMO - FrontEnd.ro
+        </title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <>
@@ -30,10 +34,12 @@ export default function NoopenerNoreferrerRel() {
           </DemoPreview>
           <p>
             Când folosim valoarea _blank, e recomandat să adăugăm un nou atribut
-            pentru securitate și anume :{' '}
+            pentru securitate și anume :
+            {' '}
             <FormattedText as="strong">
               rel cu valorile ”noopener noreferrer”.
-            </FormattedText>{' '}
+            </FormattedText>
+            {' '}
           </p>
           <Highlight
             className="my-5"

--- a/pages/demo/html/video.tsx
+++ b/pages/demo/html/video.tsx
@@ -21,8 +21,11 @@ export default function Video() {
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Exemplu de utilizare a elementului{' '}
-            <FormattedText as="strong">{'<video>'}</FormattedText> ce specifică
+            Exemplu de utilizare a elementului
+            {' '}
+            <FormattedText as="strong">{'<video>'}</FormattedText>
+            {' '}
+            ce specifică
             mai multe surse:
           </p>
           <DemoPreview>
@@ -39,7 +42,8 @@ export default function Video() {
               />
 
               <p>
-                Browser-ul tău nu suportă fișiere video. Folosește{' '}
+                Browser-ul tău nu suportă fișiere video. Folosește
+                {' '}
                 <a
                   href={`${process.env.CLOUDFRONT_PUBLIC}/demo-assets/audio-video/big-buck-bunny-video.mp4`}
                 >

--- a/pages/demo/html/video.tsx
+++ b/pages/demo/html/video.tsx
@@ -5,6 +5,7 @@ import Header from '~/components/Header';
 import Footer from '~/components/Footer';
 import SEOTags from '~/components/SEOTags';
 import Highlight from '~/components/Highlight/Highlight';
+import FormattedText from '~/components/FormattedText';
 
 export default function Video() {
   const title = 'Elementul <video>';
@@ -20,11 +21,9 @@ export default function Video() {
         <Header demoPage withNavMenu />
         <Demo title={title}>
           <p>
-            Exemplu de utilizare a elementului
-            {' '}
-            <strong className="formatted">{'<video>'}</strong>
-            {' '}
-            ce specifică mai multe surse:
+            Exemplu de utilizare a elementului{' '}
+            <FormattedText as="strong">{'<video>'}</FormattedText> ce specifică
+            mai multe surse:
           </p>
           <DemoPreview>
             {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
@@ -40,13 +39,14 @@ export default function Video() {
               />
 
               <p>
-                Browser-ul tău nu suportă fișiere video.
-                Folosește
-                {' '}
-                <a href={`${process.env.CLOUDFRONT_PUBLIC}/demo-assets/audio-video/big-buck-bunny-video.mp4`}>acest link</a>
+                Browser-ul tău nu suportă fișiere video. Folosește{' '}
+                <a
+                  href={`${process.env.CLOUDFRONT_PUBLIC}/demo-assets/audio-video/big-buck-bunny-video.mp4`}
+                >
+                  acest link
+                </a>
                 pentru a-l putea vizualiza.
               </p>
-
             </video>
           </DemoPreview>
           <Highlight


### PR DESCRIPTION
Previously formatted text was used in form of a className `formatted` which was styled separately.
So too many formatted class got introduced to code.

Now separated formatted text into a separate component in `/client/components/FormattedText` which allows to use it anywhere with any type of `HTML` element with corresponding `attributes`.

-[x] Linting done (All though found some not so important errors, specially related to code formatting and no-used vars)
-[ ] Build was incomplete due to `yarn lint` incompletion

That's it from me !!