### PR TITLE
Center the icon hide / show password

### DIFF
--- a/client/components/Form/PasswordReveal/PasswordReveal.module.scss
+++ b/client/components/Form/PasswordReveal/PasswordReveal.module.scss
@@ -8,7 +8,7 @@
     border: 0;
     height: 32px;
     width: 32px;
-    top: 0.25em;
+    top: -2px;
     align-items: center;
     right: 0;
     cursor: pointer;


### PR DESCRIPTION
The update I did is: I centered the icon hide / show password.